### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Unit/Campaign/CampaignDetectorTest.php
+++ b/tests/Unit/Campaign/CampaignDetectorTest.php
@@ -17,12 +17,13 @@ use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignMedium;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignName;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignSource;
 use Piwik\Tracker\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group MarketingCampaignsReporting
  * @group Plugins
  */
-class CampaignDetectorTest extends \PHPUnit_Framework_TestCase
+class CampaignDetectorTest extends TestCase
 {
     /**
      * @dataProvider provideRequestData


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

refs piwik/piwik#12269