### PR TITLE
Use registerEvents instead of getListHooksRegistered, as it is deprecated

### DIFF
--- a/MarketingCampaignsReporting.php
+++ b/MarketingCampaignsReporting.php
@@ -28,7 +28,7 @@ class MarketingCampaignsReporting extends \Piwik\Plugin
     public static $CAMPAIGN_CONTENT_FIELD_DEFAULT_URL_PARAMS = array('pk_content', 'utm_content');
     public static $CAMPAIGN_ID_FIELD_DEFAULT_URL_PARAMS      = array('pk_cid', 'utm_id');
 
-    public function getListHooksRegistered()
+    public function registerEvents()
     {
         return array(
             'Tracker.PageUrl.getQueryParametersToExclude' => 'getQueryParametersToExclude',


### PR DESCRIPTION
`getListHooksRegistered` is deprecated since Piwik 2.15. So should be safe to merge directly.