### PR TITLE
Fix possible error when installing plugin

### DIFF
--- a/MarketingCampaignsReporting.php
+++ b/MarketingCampaignsReporting.php
@@ -49,7 +49,7 @@ class MarketingCampaignsReporting extends Plugin
     {
         $tables = \Piwik\DbHelper::getTablesInstalled();
         foreach ($tables as $tableName) {
-            if (strpos($tableName, 'archive_') !== false) {
+            if (strpos($tableName, 'archive_blob_') !== false || strpos($tableName, 'archive_numeric_') !== false) {
                 Db::exec('UPDATE `' . $tableName . '` SET `name`=REPLACE(`name`, \'AdvancedCampaignReporting_\', \'MarketingCampaignsReporting_\') WHERE `name` LIKE \'AdvancedCampaignReporting_%\'');
             }
         }


### PR DESCRIPTION
Currently testing Matomo 4 on cloud and after lot of debugging noticed one issue why accounts couldn't be set up anymore which is because we have some other table with `archive` in it that doesn't have a `name` column. Also there is no `archive_invalidations`.