### PR TITLE
On existing visit if referrer type is currently direct entry, and campaign information appears, update dimensions to match core behavior.

### DIFF
--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -69,6 +69,32 @@ abstract class Base extends VisitDimension
         return null;
     }
 
+    public function onExistingVisit(Request $request, Visitor $visitor, $action)
+    {
+        $campaignDetector   = StaticContainer::get('advanced_campaign_reporting.campaign_detector');
+        $campaignParameters = MarketingCampaignsReporting::getCampaignParameters();
+
+        $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
+            $request,
+            $campaignParameters
+        );
+
+        if ($this->isCurrentReferrerDirectEntry($visitor)
+            && !empty($campaignDimensions)
+            && array_key_exists($this->getColumnName(), $campaignDimensions)
+        ) {
+            return substr($campaignDimensions[$this->getColumnName()], 0, $this->getColumnName() == 'campaign_id' ? 100 : 255);
+        }
+
+        return false;
+    }
+
+    protected function isCurrentReferrerDirectEntry(Visitor $visitor)
+    {
+        $referrerType = $visitor->getVisitorColumn('referer_type');
+        return $referrerType == Common::REFERRER_TYPE_DIRECT_ENTRY;
+    }
+
     /**
      * @param Request     $request
      * @param Visitor     $visitor

--- a/stylesheets/styles.less
+++ b/stylesheets/styles.less
@@ -1,5 +1,4 @@
 .visitorReferrer.campaign {
-  display: none; /* do not show default campaign information in visitor log */
 }
 
 .visitorCampaign {


### PR DESCRIPTION
…paign information appears, update dimensions to match core behavior.

Tests don't currently pass and it doesn't appear trivial to find out why.
