### PR TITLE
Allow create_new_visit_when_campaign_changes to be different per site if necessary

### DIFF
--- a/Columns/CampaignName.php
+++ b/Columns/CampaignName.php
@@ -37,7 +37,7 @@ class CampaignName extends Base
      */
     public function shouldForceNewVisit(Request $request, Visitor $visitor, Action $action = null)
     {
-        if (TrackerConfig::getConfigValue('create_new_visit_when_campaign_changes') != 1) {
+        if (TrackerConfig::getConfigValue('create_new_visit_when_campaign_changes', $request->getIdSiteIfExists()) != 1) {
             return false;
         }
 


### PR DESCRIPTION
### Description:

Saw this branch locally, must have forgotten to push it.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
