### PR TITLE
Fix for single and double quote encoding in campaign names

### DIFF
--- a/VisitorDetails.php
+++ b/VisitorDetails.php
@@ -49,7 +49,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
         foreach ($fields as $field => $name) {
             if (!empty($visitorDetails[$field])) {
-                $campaignData[$name] = $visitorDetails[$field];
+                $campaignData[$name] = html_entity_decode($visitorDetails[$field], ENT_QUOTES, 'UTF-8');
             }
         }
 


### PR DESCRIPTION
### Description:

Fixes single and double quotes in campaign names not correctly displayed in the visitor log.

Tracking a page with `?pk_campaign=te%27%22st` as the campaign url will result in `te#&039;&quot;st` being shown on the visitor log instead of `te'"st`. This fix adds an `html_entity_decode` for to the rendered view details.

See matomo-org/matomo#18170

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
