### PR TITLE
Fix deprecation warnings on PHP 8.1

### DIFF
--- a/Campaign/CampaignDetector.php
+++ b/Campaign/CampaignDetector.php
@@ -82,7 +82,7 @@ class CampaignDetector implements CampaignDetectorInterface
      */
     protected function getValueFromQueryString($param, $queryString)
     {
-        $valueFromRequest = UrlHelper::getParameterFromQueryString($queryString, $param);
+        $valueFromRequest = UrlHelper::getParameterFromQueryString($queryString, $param) ?? '';
         $valueFromRequest = trim(urldecode($valueFromRequest));
         $valueFromRequest = Common::mb_strtolower($valueFromRequest);
         $valueFromRequest = substr($valueFromRequest, 0, 250);

--- a/Columns/CampaignName.php
+++ b/Columns/CampaignName.php
@@ -76,7 +76,7 @@ class CampaignName extends Base
 
     protected function hasReferrerColumnChanged(Visitor $visitor, $information, $infoName)
     {
-        $existing = Common::mb_strtolower($visitor->getVisitorColumn($infoName));
+        $existing = Common::mb_strtolower($visitor->getVisitorColumn($infoName) ?? '');
         $new      = isset($information[$infoName]) ? Common::mb_strtolower($information[$infoName]) : false;
 
         $result = $existing != $new;


### PR DESCRIPTION
### Description:

Following errors occurred while generating visits:

```
PHP Deprecated:  urldecode(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/matomo/plugins/MarketingCampaignsReporting/Campaign/CampaignDetector.php on line 86
```

```
PHP Deprecated:  mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/matomo/core/Common.php on line 246
...
PHP  12. Piwik\Common::mb_strtolower($string = NULL) /srv/matomo/plugins/MarketingCampaignsReporting/Columns/CampaignName.php:79
```


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
