### PR TITLE
Don't try to detect a campaign if core detected an AI agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-#### 5.1.3 - 2025-10-09
+#### 5.1.3 - 2025-10-13
 - Fix for handling AI referrers correctly, providing utm_source parameter
 
 #### 5.1.2 - 2025-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### 5.1.3 - 2025-10-09
+- Fix for handling AI referrers correctly, providing utm_source parameter
+
 #### 5.1.2 - 2025-07-21
 - README.md updated
 

--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -44,6 +44,11 @@ abstract class Base extends VisitDimension
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
+        // @todo Not using Common::REFERRER_TYPE_AI_ASSISTANT for BC reasons. Can be changed with Matomo 6
+        if ($visitProperties['referer_type'] === 8) {
+            return null; // skip campaign detection when a AI assistant was detected as referrer by core
+        }
+
         $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
             $request,
             $campaignParameters
@@ -81,6 +86,11 @@ abstract class Base extends VisitDimension
         $campaignParameters = MarketingCampaignsReporting::getCampaignParameters();
 
         $visitProperties = $visitor->visitProperties->getProperties();
+
+        // @todo Not using Common::REFERRER_TYPE_AI_ASSISTANT for BC reasons. Can be changed with Matomo 6
+        if ($visitProperties['referer_type'] === 8) {
+            return null; // skip campaign detection when a AI assistant was detected as referrer by core
+        }
 
         $campaignDimensions = $campaignDetector->detectCampaignFromVisit(
             $visitProperties,

--- a/Tracker/RequestProcessor.php
+++ b/Tracker/RequestProcessor.php
@@ -24,6 +24,11 @@ class RequestProcessor extends Tracker\RequestProcessor
 {
     public function onNewVisit(Tracker\Visit\VisitProperties $visitProperties, Tracker\Request $request)
     {
+        // @todo Not using Common::REFERRER_TYPE_AI_ASSISTANT for BC reasons. Can be changed with Matomo 6
+        if ($visitProperties->getProperty('referer_type') === 8) {
+            return; // skip campaign detection when a AI assistant was detected as referrer by core
+        }
+
         $campaignName      = $visitProperties->getProperty((new CampaignName())->getColumnName());
         $campaignKeyword   = $visitProperties->getProperty((new CampaignKeyword())->getColumnName());
         $campaignMedium    = $visitProperties->getProperty((new CampaignMedium())->getColumnName());

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "MarketingCampaignsReporting",
     "description": "Measure the effectiveness of your marketing campaigns. New reports, segments & track up to five channels: campaign, source, medium, keyword, content.",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "keywords": ["Campaign", "Marketing", "Channels", "UTM tags"],
     "license": "GPL v3+",
     "homepage": "https://matomo.org",

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\MarketingCampaignsReporting\tests\Integration;
+
+use Piwik\Common;
+use Piwik\Date;
+use Piwik\Db;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Version;
+
+/**
+ * @group MarketingCampaignsReporting
+ * @group Plugins
+ */
+class CorrectCampaignDetectionTest extends IntegrationTestCase
+{
+    protected $idSite = null;
+
+    /**
+     * @var Date
+     */
+    protected $testDate = null;
+
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->idSite = Fixture::createWebsite('2016-01-01 00:00:01', 0, 'TestSite', 'https://example.com');
+    }
+
+    /**
+     * @dataProvider getTrackingTestData
+     */
+    public function testTracking(string $url, string $referrerUrl, array $expectedAttributes)
+    {
+        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_visit'));
+
+        $t = Fixture::getTracker(
+            $this->idSite,
+            date('Y-m-d H:i:s'),
+            $defaultInit = true,
+            $useLocal = false
+        );
+
+        $t->setUrl($url);
+        $t->setUrlReferrer($referrerUrl);
+
+        Fixture::checkResponse($t->doTrackPageView('Some page title'));
+
+
+        $data = Db::fetchRow('SELECT * FROM ' . Common::prefixTable('log_visit') . ' LIMIT 1');
+
+        foreach ($expectedAttributes as $name => $value) {
+            self::assertEquals($value, $data[$name] ?? '');
+        }
+    }
+
+    public function getTrackingTestData(): iterable
+    {
+
+        yield 'provided compaign parameters should be detected correctly' => [
+            'https://www.example.com/?utm_campaign=November_Offer&utm_term=Mot_clé_PÉPÈRE&utm_source=newsletter_7&utm_content=contains personalized campaigns for client&utm_medium=email&utm_id=CAMPAIGN_ID_KABOOM&mtm_group=Audience%20Group%201&mtm_placement=Google%20Search',
+            '', // no referer
+            [
+                'referer_type'       => Common::REFERRER_TYPE_CAMPAIGN,
+                'referer_name'       => 'November_Offer',
+                'referer_url'        => '',
+                'referer_keyword'    => 'Mot_clé_PÉPÈRE',
+                'campaign_content'   => 'contains personalized campaigns for client',
+                'campaign_group'     => 'Audience Group 1',
+                'campaign_id'        => 'CAMPAIGN_ID_KABOOM',
+                'campaign_keyword'   => 'Mot_clé_PÉPÈRE',
+                'campaign_medium'    => 'email',
+                'campaign_name'      => 'November_Offer',
+                'campaign_placement' => 'Google Search',
+                'campaign_source'    => 'newsletter_7',
+            ],
+        ];
+
+        if (version_compare(Version::VERSION, '5.5.0-b1', '>=')) {
+            yield 'utm_source param provided by ChatGPT is detected as AI assistant' => [
+                'https://www.example.com/?utm_source=chatgpt.com',
+                '', // not referer
+                [
+                    'referer_type'       => Common::REFERRER_TYPE_AI_ASSISTANT,
+                    'referer_name'       => 'ChatGPT',
+                    'referer_url'        => '',
+                    'referer_keyword'    => '',
+                    'campaign_content'   => '',
+                    'campaign_group'     => '',
+                    'campaign_id'        => '',
+                    'campaign_keyword'   => '',
+                    'campaign_medium'    => '',
+                    'campaign_name'      => '',
+                    'campaign_placement' => '',
+                    'campaign_source'    => '',
+                ],
+            ];
+
+            yield 'ChatGPT referrer with utm_source param is detected as AI assistant' => [
+                'https://www.example.com/?utm_source=chatgpt.com',
+                'https://chatgpt.com/',
+                [
+                    'referer_type'       => Common::REFERRER_TYPE_AI_ASSISTANT,
+                    'referer_name'       => 'ChatGPT',
+                    'referer_url'        => 'https://chatgpt.com/',
+                    'referer_keyword'    => '',
+                    'campaign_content'   => '',
+                    'campaign_group'     => '',
+                    'campaign_id'        => '',
+                    'campaign_keyword'   => '',
+                    'campaign_medium'    => '',
+                    'campaign_name'      => '',
+                    'campaign_placement' => '',
+                    'campaign_source'    => '',
+                ],
+            ];
+
+            yield 'utm_source param provided by Perplexity is detected as AI assistant' => [
+                'https://www.example.com/?utm_source=perplexity.ai',
+                '', // no referer
+                [
+                    'referer_type'       => Common::REFERRER_TYPE_AI_ASSISTANT,
+                    'referer_name'       => 'Perplexity',
+                    'referer_url'        => '',
+                    'referer_keyword'    => '',
+                    'campaign_content'   => '',
+                    'campaign_group'     => '',
+                    'campaign_id'        => '',
+                    'campaign_keyword'   => '',
+                    'campaign_medium'    => '',
+                    'campaign_name'      => '',
+                    'campaign_placement' => '',
+                    'campaign_source'    => '',
+                ],
+            ];
+        }
+    }
+}

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -106,6 +106,25 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
                 ],
             ];
 
+            yield 'campaign parameters are ignored for AI referrers' => [
+                'https://www.example.com/?utm_source=random&utm_campaign=random',
+                'https://chatgpt.com/',
+                [
+                    'referer_type'       => Common::REFERRER_TYPE_AI_ASSISTANT,
+                    'referer_name'       => 'ChatGPT',
+                    'referer_url'        => 'https://chatgpt.com/',
+                    'referer_keyword'    => '',
+                    'campaign_content'   => '',
+                    'campaign_group'     => '',
+                    'campaign_id'        => '',
+                    'campaign_keyword'   => '',
+                    'campaign_medium'    => '',
+                    'campaign_name'      => '',
+                    'campaign_placement' => '',
+                    'campaign_source'    => '',
+                ],
+            ];
+
             yield 'ChatGPT referrer with utm_source param is detected as AI assistant' => [
                 'https://www.example.com/?utm_source=chatgpt.com',
                 'https://chatgpt.com/',


### PR DESCRIPTION
## Description
ChatGPT and Perplexity are often providing a `utm_source` when referring to external sites.

Matomo meanwhile detects those as AI Assistants. However, this plugin currently would overwrite the detection again as campaign, which needs to be avoided.

The implementation is very hackish, as a proper solution would need so bigger refactoring in core. This will be covered in https://github.com/matomo-org/matomo/issues/20067
