### PR TITLE
Avoid incorrectly forcing new visit when AI Assistants provide utm_source parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### 5.1.4 - 2025-11-10
+- Fixed incorrectly forcing a new visit for visits referred by AI referrers
+
 #### 5.1.3 - 2025-10-13
 - Fix for handling AI referrers correctly, providing utm_source parameter
 

--- a/Columns/CampaignName.php
+++ b/Columns/CampaignName.php
@@ -51,6 +51,20 @@ class CampaignName extends Base
             $campaignParameters
         );
 
+        // Never start a new visit, if the visit was detected as AI Assistant by core, unless
+        // there are campaign parameters detected, that do not resolve to an AI Assistant.
+        // This is a hacky workaround to solves issues where randomly new visits are started when
+        // e.g. someone comes from ChatGPT having the `utm_source=chatgpt.com` url parameter.
+        // That one will be detected as AI Assistant by core. But if someone reloads that page
+        // and the utm source is still present, the check here might otherwise force a new visit,
+        // if the `utm_source` parameter is configured.
+        if ((int)$visitor->getVisitorColumn('referer_type') === 8 && count($campaignDimensions) === 1) {
+            $paramValue = reset($campaignDimensions);
+            if (class_exists('Piwik\Plugins\Referrers\AIAssistant') && \Piwik\Plugins\Referrers\AIAssistant::getInstance()->getAIAssistantFromDomain($paramValue)) {
+                return false;
+            }
+        }
+
         // we force a new visit if the referrer is a campaign and it's different than the currently recorded referrer.
         // if the current referrer is 'direct entry', however, we assume the referrer information was sent in a later request, and
         // we just update the existing referrer information instead of creating a visit.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "MarketingCampaignsReporting",
     "description": "Measure the effectiveness of your marketing campaigns. New reports, segments & track up to five channels: campaign, source, medium, keyword, content.",
-    "version": "5.1.3",
+    "version": "5.1.4",
     "keywords": ["Campaign", "Marketing", "Channels", "UTM tags"],
     "license": "GPL v3+",
     "homepage": "https://matomo.org",

--- a/tests/Integration/ForceNewVisitTest.php
+++ b/tests/Integration/ForceNewVisitTest.php
@@ -47,7 +47,7 @@ class ForceNewVisitTest extends IntegrationTestCase
         $configOverride['MarketingCampaignsReporting'] = [
             (new CampaignName())->getColumnName()      => 'pk_campaign,custom_name_parameter',
             (new CampaignKeyword())->getColumnName()   => 'pk_keyword,custom_keyword_parameter',
-            (new CampaignSource())->getColumnName()    => 'pk_source,custom_source_parameter',
+            (new CampaignSource())->getColumnName()    => 'utm_source,pk_source,custom_source_parameter',
             (new CampaignMedium())->getColumnName()    => 'pk_medium,custom_medium_parameter',
             (new CampaignContent())->getColumnName()   => 'pk_content,custom_content_parameter',
             (new CampaignId())->getColumnName()        => 'pk_id,custom_id_parameter',
@@ -207,6 +207,46 @@ class ForceNewVisitTest extends IntegrationTestCase
         $this->tracker->setUrl($url);
 
         Fixture::checkResponse($this->tracker->doTrackPageView('Track another visit with different campaign parameters'));
+
+        $this->assertVisits(2, 1, 2);
+    }
+
+    public function testTrackingAIAssistantDoesNotForceNewVisit(): void
+    {
+        $url = $this->getUrlForTracking(['utm_source' => 'chatgpt.com']);
+
+        $this->tracker->setUrl($url);
+        $this->tracker->setUrlReferrer('https://chatgpt.com');
+
+        Fixture::checkResponse($this->tracker->doTrackPageView('Track visit'));
+
+        $this->assertVisits(1, 1, 1);
+
+        // simulating a page reload
+        $this->moveTimeForward(0.05);
+        $this->tracker->setUrlReferrer('');
+        Fixture::checkResponse($this->tracker->doTrackPageView('Track visit'));
+
+        $this->assertVisits(1, 1, 2);
+    }
+
+    public function testCampaignAfterAIAssistantForcesNewVisit(): void
+    {
+        $url = $this->getUrlForTracking(['utm_source' => 'chatgpt.com']);
+
+        $this->tracker->setUrl($url);
+        $this->tracker->setUrlReferrer('https://chatgpt.com');
+
+        Fixture::checkResponse($this->tracker->doTrackPageView('Track visit'));
+
+        $this->assertVisits(1, 1, 1);
+
+        $this->moveTimeForward(0.05);
+        $this->tracker->setUrlReferrer('');
+        $url = $this->getUrlForTracking(['pk_campaign' => 'custom name']);
+
+        $this->tracker->setUrl($url);
+        Fixture::checkResponse($this->tracker->doTrackPageView('Track visit'));
 
         $this->assertVisits(2, 1, 2);
     }


### PR DESCRIPTION
## Description

If A visitor currently comes from ChatGPT to a website, ChatGPT might attach `utm_source=chatgpt.com` to the url. Matomo and this plugin are currently not considering this parameter for new visits, if it can be detected as AI Assistant.

However, if the `utm_source` parameter persists, e.g. after page reload, the plugin might currently force a new visit. This should be avoided, unless new campaign parameters are provided, that don't resolve to an AI Assistant.

fixes matomo-org/matomo#23708


## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔/✖] Tested locally or on demo2/demo3?
- [✔/✖/NA] New test case added/updated?
- [✔/✖/NA] Are all newly added texts included via translation?
- [✔/✖/NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔/✖/NA] Version bumped?