### PR TITLE
campaign parameters now masked with CNIL active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### 5.2.0 - 2026-05-11
+- added support for campaign masking via CNIL policy
+
 #### 5.1.7 - 2026-04-27
 - Updated API documentation
 

--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -42,7 +42,6 @@ abstract class Base extends VisitDimension
     {
         $campaignDetector   = StaticContainer::get('advanced_campaign_reporting.campaign_detector');
         $campaignParameters = MarketingCampaignsReporting::getCampaignParameters();
-        $isCampaignValuesMasked = MarketingCampaignsReporting::isCampaignValuesMaskingEnabled((int) $request->getIdSiteIfExists());
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
@@ -55,7 +54,10 @@ abstract class Base extends VisitDimension
             $request,
             $campaignParameters
         );
-        $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $isCampaignValuesMasked);
+        $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+            $campaignDimensions,
+            (int) $request->getIdSiteIfExists()
+        );
 
         if (empty($campaignDimensions)) {
             // If for some reason a campaign was detected in Core Tracker
@@ -87,7 +89,6 @@ abstract class Base extends VisitDimension
     {
         $campaignDetector   = StaticContainer::get('advanced_campaign_reporting.campaign_detector');
         $campaignParameters = MarketingCampaignsReporting::getCampaignParameters();
-        $isCampaignValuesMasked = MarketingCampaignsReporting::isCampaignValuesMaskingEnabled((int) $request->getIdSiteIfExists());
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
@@ -100,14 +101,20 @@ abstract class Base extends VisitDimension
             $visitProperties,
             $campaignParameters
         );
-        $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $isCampaignValuesMasked);
+        $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+            $campaignDimensions,
+            (int) $request->getIdSiteIfExists()
+        );
 
         if (empty($campaignDimensions)) {
             $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
                 $request,
                 $campaignParameters
             );
-            $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $isCampaignValuesMasked);
+            $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+                $campaignDimensions,
+                (int) $request->getIdSiteIfExists()
+            );
         }
 
         if (!empty($campaignDimensions) && array_key_exists($this->getColumnName(), $campaignDimensions)) {
@@ -120,6 +127,14 @@ abstract class Base extends VisitDimension
     public function formatValue($value, $idSite, Formatter $formatter)
     {
         return MarketingCampaignsReporting::formatCampaignValue($value);
+    }
+
+    protected function normalizeDetectedCampaignDimensions($campaignDimensions, int $idSite)
+    {
+        return $this->maskDetectedCampaignDimensions(
+            $campaignDimensions,
+            MarketingCampaignsReporting::isCampaignValuesMaskingEnabled($idSite)
+        );
     }
 
     private function maskDetectedCampaignDimensions($campaignDimensions, bool $campaignValuesMasked)

--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -42,7 +42,7 @@ abstract class Base extends VisitDimension
     {
         $campaignDetector   = StaticContainer::get('advanced_campaign_reporting.campaign_detector');
         $campaignParameters = MarketingCampaignsReporting::getCampaignParameters();
-        $campaignValuesMasked = MarketingCampaignsReporting::isCampaignValuesMaskingEnabled((int) $request->getIdSiteIfExists());
+        $isCampaignValuesMasked = MarketingCampaignsReporting::isCampaignValuesMaskingEnabled((int) $request->getIdSiteIfExists());
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
@@ -55,7 +55,7 @@ abstract class Base extends VisitDimension
             $request,
             $campaignParameters
         );
-        $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $campaignValuesMasked);
+        $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $isCampaignValuesMasked);
 
         if (empty($campaignDimensions)) {
             // If for some reason a campaign was detected in Core Tracker
@@ -87,7 +87,7 @@ abstract class Base extends VisitDimension
     {
         $campaignDetector   = StaticContainer::get('advanced_campaign_reporting.campaign_detector');
         $campaignParameters = MarketingCampaignsReporting::getCampaignParameters();
-        $campaignValuesMasked = MarketingCampaignsReporting::isCampaignValuesMaskingEnabled((int) $request->getIdSiteIfExists());
+        $isCampaignValuesMasked = MarketingCampaignsReporting::isCampaignValuesMaskingEnabled((int) $request->getIdSiteIfExists());
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
@@ -100,14 +100,14 @@ abstract class Base extends VisitDimension
             $visitProperties,
             $campaignParameters
         );
-        $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $campaignValuesMasked);
+        $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $isCampaignValuesMasked);
 
         if (empty($campaignDimensions)) {
             $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
                 $request,
                 $campaignParameters
             );
-            $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $campaignValuesMasked);
+            $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $isCampaignValuesMasked);
         }
 
         if (!empty($campaignDimensions) && array_key_exists($this->getColumnName(), $campaignDimensions)) {
@@ -128,6 +128,7 @@ abstract class Base extends VisitDimension
             return $campaignDimensions;
         }
 
+        // Mask every campaign field once a campaign is detected so partial URLs cannot leak raw values.
         foreach (MarketingCampaignsReporting::getAdvancedCampaignFields() as $field) {
             $campaignDimensions[$field] = MarketingCampaignsReporting::getCampaignPlaceholderValue();
         }

--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\MarketingCampaignsReporting\Columns;
 
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
+use Piwik\Metrics\Formatter;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
 use Piwik\Tracker\Action;
@@ -41,6 +42,7 @@ abstract class Base extends VisitDimension
     {
         $campaignDetector   = StaticContainer::get('advanced_campaign_reporting.campaign_detector');
         $campaignParameters = MarketingCampaignsReporting::getCampaignParameters();
+        $campaignValuesMasked = MarketingCampaignsReporting::isCampaignValuesMaskingEnabled((int) $request->getIdSiteIfExists());
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
@@ -53,6 +55,7 @@ abstract class Base extends VisitDimension
             $request,
             $campaignParameters
         );
+        $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $campaignValuesMasked);
 
         if (empty($campaignDimensions)) {
             // If for some reason a campaign was detected in Core Tracker
@@ -84,6 +87,7 @@ abstract class Base extends VisitDimension
     {
         $campaignDetector   = StaticContainer::get('advanced_campaign_reporting.campaign_detector');
         $campaignParameters = MarketingCampaignsReporting::getCampaignParameters();
+        $campaignValuesMasked = MarketingCampaignsReporting::isCampaignValuesMaskingEnabled((int) $request->getIdSiteIfExists());
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
@@ -96,12 +100,14 @@ abstract class Base extends VisitDimension
             $visitProperties,
             $campaignParameters
         );
+        $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $campaignValuesMasked);
 
         if (empty($campaignDimensions)) {
             $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
                 $request,
                 $campaignParameters
             );
+            $campaignDimensions = $this->maskDetectedCampaignDimensions($campaignDimensions, $campaignValuesMasked);
         }
 
         if (!empty($campaignDimensions) && array_key_exists($this->getColumnName(), $campaignDimensions)) {
@@ -109,5 +115,23 @@ abstract class Base extends VisitDimension
         }
 
         return null;
+    }
+
+    public function formatValue($value, $idSite, Formatter $formatter)
+    {
+        return MarketingCampaignsReporting::formatCampaignValue($value);
+    }
+
+    private function maskDetectedCampaignDimensions($campaignDimensions, bool $campaignValuesMasked)
+    {
+        if (empty($campaignDimensions) || !$campaignValuesMasked) {
+            return $campaignDimensions;
+        }
+
+        foreach (MarketingCampaignsReporting::getAdvancedCampaignFields() as $field) {
+            $campaignDimensions[$field] = MarketingCampaignsReporting::getCampaignPlaceholderValue();
+        }
+
+        return $campaignDimensions;
     }
 }

--- a/Columns/CampaignName.php
+++ b/Columns/CampaignName.php
@@ -50,6 +50,10 @@ class CampaignName extends Base
             $request,
             $campaignParameters
         );
+        $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+            $campaignDimensions,
+            (int) $request->getIdSiteIfExists()
+        );
 
         // Never start a new visit, if the visit was detected as AI Assistant by core, unless
         // there are campaign parameters detected, that do not resolve to an AI Assistant.

--- a/Columns/CampaignSourceMedium.php
+++ b/Columns/CampaignSourceMedium.php
@@ -11,12 +11,23 @@
 namespace Piwik\Plugins\MarketingCampaignsReporting\Columns;
 
 use Piwik\Columns\Dimension;
+use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
+use Piwik\Plugins\MarketingCampaignsReporting\Archiver;
+use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
 
 class CampaignSourceMedium extends Dimension
 {
     public function getName()
     {
         return Piwik::translate('MarketingCampaignsReporting_CombinedSourceMedium');
+    }
+
+    public function formatValue($value, $idSite, Formatter $formatter)
+    {
+        $parts = explode(Archiver::SEPARATOR_COMBINED_DIMENSIONS, (string) $value);
+        $parts = array_map([MarketingCampaignsReporting::class, 'formatCampaignValue'], $parts);
+
+        return implode(Archiver::SEPARATOR_COMBINED_DIMENSIONS, $parts);
     }
 }

--- a/MarketingCampaignsReporting.php
+++ b/MarketingCampaignsReporting.php
@@ -139,6 +139,15 @@ class MarketingCampaignsReporting extends Plugin
         return $settingClass::getPlaceholderValue();
     }
 
+    /**
+     * Formats stored campaign values for display.
+     *
+     * Accepts mixed input because callers may pass placeholder values or raw
+     * dimension values without first narrowing the type.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public static function formatCampaignValue($value)
     {
         $settingClass = self::getCampaignValuesMaskedSettingClass();

--- a/MarketingCampaignsReporting.php
+++ b/MarketingCampaignsReporting.php
@@ -24,6 +24,8 @@ use Piwik\Plugins\Referrers\Reports\GetCampaigns;
  */
 class MarketingCampaignsReporting extends Plugin
 {
+    private const CAMPAIGN_VALUES_MASKED_SETTING_CLASS = 'Piwik\\Plugins\\PrivacyManager\\Settings\\CampaignParameterValuesMasked';
+
     public static $CAMPAIGN_NAME_FIELD_DEFAULT_URL_PARAMS = array('mtm_campaign', 'matomo_campaign', 'mtm_cpn', 'pk_campaign', 'piwik_campaign', 'pk_cpn', 'utm_campaign');
     public static $CAMPAIGN_KEYWORD_FIELD_DEFAULT_URL_PARAMS = array('mtm_keyword', 'matomo_kwd', 'mtm_kwd', 'pk_keyword', 'piwik_kwd', 'pk_kwd', 'utm_term');
     public static $CAMPAIGN_SOURCE_FIELD_DEFAULT_URL_PARAMS = array('mtm_source', 'pk_source', 'utm_source');
@@ -115,6 +117,45 @@ class MarketingCampaignsReporting extends Plugin
         }
 
         return $campaignFields;
+    }
+
+    public static function isCampaignValuesMaskingEnabled(?int $idSite): bool
+    {
+        $settingClass = self::getCampaignValuesMaskedSettingClass();
+        if (empty($settingClass)) {
+            return false;
+        }
+
+        return $settingClass::isEnabled($idSite);
+    }
+
+    public static function getCampaignPlaceholderValue(): string
+    {
+        $settingClass = self::getCampaignValuesMaskedSettingClass();
+        if (empty($settingClass)) {
+            return '';
+        }
+
+        return $settingClass::getPlaceholderValue();
+    }
+
+    public static function formatCampaignValue($value)
+    {
+        $settingClass = self::getCampaignValuesMaskedSettingClass();
+        if (empty($settingClass)) {
+            return $value;
+        }
+
+        return $settingClass::formatValue($value);
+    }
+
+    private static function getCampaignValuesMaskedSettingClass(): ?string
+    {
+        if (!class_exists(self::CAMPAIGN_VALUES_MASKED_SETTING_CLASS)) {
+            return null;
+        }
+
+        return self::CAMPAIGN_VALUES_MASKED_SETTING_CLASS;
     }
 
     public function isTrackerPlugin()

--- a/VisitorDetails.php
+++ b/VisitorDetails.php
@@ -30,7 +30,7 @@ class VisitorDetails extends VisitorDetailsAbstract
         );
 
         foreach ($fields as $name => $field) {
-            $visitor[$name] = empty($this->details[$field]) ? '' : $this->details[$field];
+            $visitor[$name] = empty($this->details[$field]) ? '' : MarketingCampaignsReporting::formatCampaignValue($this->details[$field]);
         }
     }
 

--- a/VisitorDetails.php
+++ b/VisitorDetails.php
@@ -50,7 +50,8 @@ class VisitorDetails extends VisitorDetailsAbstract
 
         foreach ($fields as $field => $name) {
             if (!empty($visitorDetails[$field])) {
-                $campaignData[$name] = html_entity_decode($visitorDetails[$field], ENT_QUOTES, 'UTF-8');
+                $value = html_entity_decode($visitorDetails[$field], ENT_QUOTES, 'UTF-8');
+                $campaignData[$name] = MarketingCampaignsReporting::formatCampaignValue($value);
             }
         }
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "MarketingCampaignsReporting",
     "description": "Measure the effectiveness of your marketing campaigns. New reports, segments & track up to five channels: campaign, source, medium, keyword, content.",
-    "version": "5.1.7",
+    "version": "5.2.0",
     "keywords": ["Campaign", "Marketing", "Channels", "UTM tags"],
     "license": "GPL v3+",
     "homepage": "https://matomo.org",

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -12,6 +12,12 @@ namespace Piwik\Plugins\MarketingCampaignsReporting\tests\Integration;
 use Piwik\Common;
 use Piwik\Date;
 use Piwik\Db;
+use Piwik\Metrics\Formatter;
+use Piwik\Piwik;
+use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignName;
+use Piwik\Plugins\Referrers\Columns\ReferrerName;
+use Piwik\Policy\CnilPolicy;
+use Piwik\Policy\PolicyManager;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Version;
@@ -163,5 +169,78 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
                 ],
             ];
         }
+    }
+
+    public function testTrackingMasksCampaignDimensionsWhenCnilPolicyIsEnabled()
+    {
+        $settingClass = $this->getCampaignValuesMaskedSettingClass();
+        if (empty($settingClass)) {
+            $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
+        }
+
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true, $this->idSite);
+        try {
+            Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_visit'));
+
+            $tracker = Fixture::getTracker(
+                $this->idSite,
+                date('Y-m-d H:i:s'),
+                $defaultInit = true,
+                $useLocal = false
+            );
+
+            $tracker->setUrl('https://www.example.com/?utm_source=newsletter_7&utm_medium=email&utm_id=CAMPAIGN_ID_KABOOM&utm_content=hero-banner&mtm_group=Audience%20Group%201&mtm_placement=Google%20Search');
+
+            Fixture::checkResponse($tracker->doTrackPageView('Some page title'));
+
+            $data = Db::fetchRow('SELECT * FROM ' . Common::prefixTable('log_visit') . ' LIMIT 1');
+            $placeholder = $settingClass::DISCARDED_CAMPAIGN_PLACEHOLDER;
+
+            self::assertEquals(Common::REFERRER_TYPE_CAMPAIGN, $data['referer_type']);
+            self::assertEquals($placeholder, $data['referer_name']);
+            self::assertEquals($placeholder, $data['referer_keyword']);
+            self::assertEquals($placeholder, $data['campaign_source']);
+            self::assertEquals($placeholder, $data['campaign_medium']);
+            self::assertEquals($placeholder, $data['campaign_content']);
+            self::assertEquals($placeholder, $data['campaign_id']);
+            self::assertEquals($placeholder, $data['campaign_group']);
+            self::assertEquals($placeholder, $data['campaign_placement']);
+            self::assertEquals($placeholder, $data['campaign_name']);
+            self::assertEquals($placeholder, $data['campaign_keyword']);
+        } finally {
+            PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false, $this->idSite);
+        }
+    }
+
+    public function testCampaignPlaceholderIsFormattedForReports()
+    {
+        $settingClass = $this->getCampaignValuesMaskedSettingClass();
+        if (empty($settingClass)) {
+            $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
+        }
+
+        $formatter = new Formatter();
+        $placeholder = $settingClass::DISCARDED_CAMPAIGN_PLACEHOLDER;
+        $expectedLabel = Piwik::translate('PrivacyManager_CampaignParameterDiscarded');
+
+        self::assertSame(
+            $expectedLabel,
+            (new CampaignName())->formatValue($placeholder, $this->idSite, $formatter)
+        );
+        self::assertSame(
+            $expectedLabel,
+            (new ReferrerName())->formatValue($placeholder, $this->idSite, $formatter)
+        );
+    }
+
+    private function getCampaignValuesMaskedSettingClass(): ?string
+    {
+        $class = 'Piwik\\Plugins\\PrivacyManager\\Settings\\CampaignParameterValuesMasked';
+
+        if (!class_exists($class)) {
+            return null;
+        }
+
+        return $class;
     }
 }

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -15,6 +15,8 @@ use Piwik\Db;
 use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignName;
+use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignSourceMedium;
+use Piwik\Plugins\MarketingCampaignsReporting\VisitorDetails;
 use Piwik\Plugins\Referrers\Columns\ReferrerName;
 use Piwik\Policy\CnilPolicy;
 use Piwik\Policy\PolicyManager;
@@ -231,6 +233,45 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
             $expectedLabel,
             (new ReferrerName())->formatValue($placeholder, $this->idSite, $formatter)
         );
+        self::assertSame(
+            $expectedLabel . ' - ' . $expectedLabel,
+            (new CampaignSourceMedium())->formatValue($placeholder . ' - ' . $placeholder, $this->idSite, $formatter)
+        );
+    }
+
+    public function testVisitorDetailsFormatsMaskedCampaignValuesForApi()
+    {
+        $settingClass = $this->getCampaignValuesMaskedSettingClass();
+        if (empty($settingClass)) {
+            $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
+        }
+
+        $placeholder = $settingClass::DISCARDED_CAMPAIGN_PLACEHOLDER;
+        $expectedLabel = Piwik::translate('PrivacyManager_CampaignParameterDiscarded');
+
+        $visitorDetails = new VisitorDetails();
+        $visitorDetails->setDetails([
+            'campaign_id' => $placeholder,
+            'campaign_content' => $placeholder,
+            'campaign_keyword' => $placeholder,
+            'campaign_medium' => $placeholder,
+            'campaign_name' => $placeholder,
+            'campaign_source' => $placeholder,
+            'campaign_group' => $placeholder,
+            'campaign_placement' => $placeholder,
+        ]);
+
+        $visitor = [];
+        $visitorDetails->extendVisitorDetails($visitor);
+
+        self::assertSame($expectedLabel, $visitor['campaignId']);
+        self::assertSame($expectedLabel, $visitor['campaignContent']);
+        self::assertSame($expectedLabel, $visitor['campaignKeyword']);
+        self::assertSame($expectedLabel, $visitor['campaignMedium']);
+        self::assertSame($expectedLabel, $visitor['campaignName']);
+        self::assertSame($expectedLabel, $visitor['campaignSource']);
+        self::assertSame($expectedLabel, $visitor['campaignGroup']);
+        self::assertSame($expectedLabel, $visitor['campaignPlacement']);
     }
 
     private function getCampaignValuesMaskedSettingClass(): ?string

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -16,6 +16,7 @@ use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignName;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignSourceMedium;
+use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
 use Piwik\Plugins\MarketingCampaignsReporting\VisitorDetails;
 use Piwik\Plugins\Referrers\Columns\ReferrerName;
 use Piwik\Policy\CnilPolicy;
@@ -175,8 +176,8 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
 
     public function testTrackingMasksCampaignDimensionsWhenCnilPolicyIsEnabled()
     {
-        $settingClass = $this->getCampaignValuesMaskedSettingClass();
-        if (empty($settingClass)) {
+        $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();
+        if ($placeholder === '') {
             $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
         }
 
@@ -196,7 +197,6 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
             Fixture::checkResponse($tracker->doTrackPageView('Some page title'));
 
             $data = Db::fetchRow('SELECT * FROM ' . Common::prefixTable('log_visit') . ' LIMIT 1');
-            $placeholder = $settingClass::DISCARDED_CAMPAIGN_PLACEHOLDER;
 
             self::assertEquals(Common::REFERRER_TYPE_CAMPAIGN, $data['referer_type']);
             self::assertEquals($placeholder, $data['referer_name']);
@@ -216,13 +216,12 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
 
     public function testCampaignPlaceholderIsFormattedForReports()
     {
-        $settingClass = $this->getCampaignValuesMaskedSettingClass();
-        if (empty($settingClass)) {
+        $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();
+        if ($placeholder === '') {
             $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
         }
 
         $formatter = new Formatter();
-        $placeholder = $settingClass::DISCARDED_CAMPAIGN_PLACEHOLDER;
         $expectedLabel = Piwik::translate('PrivacyManager_CampaignParameterDiscarded');
 
         self::assertSame(
@@ -241,12 +240,11 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
 
     public function testVisitorDetailsFormatsMaskedCampaignValuesForApi()
     {
-        $settingClass = $this->getCampaignValuesMaskedSettingClass();
-        if (empty($settingClass)) {
+        $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();
+        if ($placeholder === '') {
             $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
         }
 
-        $placeholder = $settingClass::DISCARDED_CAMPAIGN_PLACEHOLDER;
         $expectedLabel = Piwik::translate('PrivacyManager_CampaignParameterDiscarded');
 
         $visitorDetails = new VisitorDetails();
@@ -272,16 +270,5 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         self::assertSame($expectedLabel, $visitor['campaignSource']);
         self::assertSame($expectedLabel, $visitor['campaignGroup']);
         self::assertSame($expectedLabel, $visitor['campaignPlacement']);
-    }
-
-    private function getCampaignValuesMaskedSettingClass(): ?string
-    {
-        $class = 'Piwik\\Plugins\\PrivacyManager\\Settings\\CampaignParameterValuesMasked';
-
-        if (!class_exists($class)) {
-            return null;
-        }
-
-        return $class;
     }
 }

--- a/tests/Integration/ForceNewVisitTest.php
+++ b/tests/Integration/ForceNewVisitTest.php
@@ -19,6 +19,8 @@ use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignMedium;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignName;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignPlacement;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignSource;
+use Piwik\Policy\CnilPolicy;
+use Piwik\Policy\PolicyManager;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -135,6 +137,55 @@ class ForceNewVisitTest extends IntegrationTestCase
         Fixture::checkResponse($this->tracker->doTrackPageView('Track another time with same campaign parameters'));
 
         $this->assertVisits(1, 1, 2);
+    }
+
+    public function testTrackingWithSameParametersDoesNotForceNewVisitWhenCampaignValuesAreMasked()
+    {
+        if (!class_exists('Piwik\\Plugins\\PrivacyManager\\Settings\\CampaignParameterValuesMasked')) {
+            $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
+        }
+
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true, $this->idSite);
+
+        try {
+            $url = $this->getUrlForTracking([
+                'pk_campaign'  => 'custom name',
+                'pk_keyword'   => 'custom keyword',
+                'pk_source'    => 'custom source',
+                'pk_medium'    => 'custom medium',
+                'pk_content'   => 'custom content',
+                'pk_id'        => 'custom id',
+                'pk_group'     => 'custom group',
+                'pk_placement' => 'custom placement',
+            ]);
+
+            $this->tracker->setUrl($url);
+
+            Fixture::checkResponse($this->tracker->doTrackPageView('Track visit with masked campaign parameters'));
+
+            $this->assertVisits(1, 1, 1);
+
+            $this->moveTimeForward(0.05);
+
+            $url = $this->getUrlForTracking([
+                'pk_campaign'  => 'custom name',
+                'pk_keyword'   => 'custom keyword',
+                'pk_source'    => 'custom source',
+                'pk_medium'    => 'custom medium',
+                'pk_content'   => 'custom content',
+                'pk_id'        => 'custom id',
+                'pk_group'     => 'custom group',
+                'pk_placement' => 'custom placement',
+            ], 'anotherpage');
+
+            $this->tracker->setUrl($url);
+
+            Fixture::checkResponse($this->tracker->doTrackPageView('Track another time with same masked campaign parameters'));
+
+            $this->assertVisits(1, 1, 2);
+        } finally {
+            PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false, $this->idSite);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Masks campaign parameter values when the CNIL policy is enabled. Refer to https://github.com/matomo-org/matomo/pull/24416 for more information.

Backwards compatibility is maintained, if the setting is not available then all new functionality is disabled.

## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✖] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [✖] Documentation updated?
