### PR TITLE
properly format CNIL masked values on reports

### DIFF
--- a/API.php
+++ b/API.php
@@ -16,6 +16,7 @@ use Piwik\Archive;
 use Piwik\DataTable;
 use Piwik\Metrics;
 use Piwik\Piwik;
+use Piwik\Plugins\MarketingCampaignsReporting\DataTable\Filter\FormatCampaignLabels;
 use Piwik\Plugins\Referrers\API as ReferrersAPI;
 
 /**
@@ -59,7 +60,8 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_ID_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -95,7 +97,8 @@ class API extends \Piwik\Plugin\API
             $dataTable          = $this->mergeDataTableMaps($dataTable, $referrersDataTable);
         }
 
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -124,14 +127,17 @@ class API extends \Piwik\Plugin\API
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_NAME_RECORD_NAME, $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable);
 
         if (!$this->isTableEmpty($dataTable)) {
-            return $this->formatCampaignLabels($dataTable);
+            $dataTable->filter(FormatCampaignLabels::class);
+            return $dataTable;
         }
 
         // try to load sub table from referrers api. That might work, if the report leading to this subtable was loaded using the referrers api fallback
         $referrersDataTable = ReferrersAPI::getInstance()->getKeywordsFromCampaignId($idSite, $period, $date, $idSubtable, $segment);
 
         if (!$this->isTableEmpty($referrersDataTable)) {
-            return $this->formatCampaignLabels($this->mergeDataTableMaps($dataTable, $referrersDataTable));
+            $dataTable = $this->mergeDataTableMaps($dataTable, $referrersDataTable);
+            $dataTable->filter(FormatCampaignLabels::class);
+            return $dataTable;
         }
 
         // if we can't find a subtable report using the id, try fetching the label to search for a subtable
@@ -139,7 +145,8 @@ class API extends \Piwik\Plugin\API
         $row           = $campaignNames->getRowFromIdSubDataTable($idSubtable);
 
         if (!$row) {
-            return $this->formatCampaignLabels($dataTable);
+            $dataTable->filter(FormatCampaignLabels::class);
+            return $dataTable;
         }
 
         $campaignName = $row->getColumn('label');
@@ -149,10 +156,13 @@ class API extends \Piwik\Plugin\API
 
         if ($campaignRow && $idSubtable = $campaignRow->getIdSubDataTable()) {
             $referrersDataTable = ReferrersAPI::getInstance()->getKeywordsFromCampaignId($idSite, $period, $date, $idSubtable, $segment);
-            return $this->formatCampaignLabels($this->mergeDataTableMaps($dataTable, $referrersDataTable));
+            $dataTable = $this->mergeDataTableMaps($dataTable, $referrersDataTable);
+            $dataTable->filter(FormatCampaignLabels::class);
+            return $dataTable;
         }
 
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -189,7 +199,8 @@ class API extends \Piwik\Plugin\API
             $dataTable = $this->mergeDataTableMaps($dataTable, $referrersDataTable);
         }
 
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -216,7 +227,8 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_SOURCE_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -243,7 +255,8 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_MEDIUM_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -270,7 +283,8 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_CONTENT_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -297,7 +311,8 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_GROUP_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -324,7 +339,8 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_PLACEMENT_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -352,7 +368,8 @@ class API extends \Piwik\Plugin\API
     public function getSourceMedium($idSite, $period, $date, $segment = false, $expanded = false, $flat = false)
     {
         $dataTable = $this->getDataTable(Archiver::HIERARCHICAL_SOURCE_MEDIUM_RECORD_NAME, $idSite, $period, $date, $segment, $expanded, $flat);
-        return $this->formatCampaignLabels($dataTable);
+        $dataTable->filter(FormatCampaignLabels::class);
+        return $dataTable;
     }
 
     /**
@@ -378,36 +395,7 @@ class API extends \Piwik\Plugin\API
     public function getNameFromSourceMediumId($idSite, $period, $date, $idSubtable, $segment = false)
     {
         $dataTable = $this->getDataTable(Archiver::HIERARCHICAL_SOURCE_MEDIUM_RECORD_NAME, $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable);
-        return $this->formatCampaignLabels($dataTable);
-    }
-
-    private function formatCampaignLabels(DataTable\DataTableInterface $dataTable)
-    {
-        if ($dataTable instanceof DataTable\Map) {
-            foreach ($dataTable->getDataTables() as $childTable) {
-                $this->formatCampaignLabels($childTable);
-            }
-
-            return $dataTable;
-        }
-
-        foreach ($dataTable->getRows() as $row) {
-            $label = $row->getColumn('label');
-            if ($label !== false) {
-                $row->setColumn('label', MarketingCampaignsReporting::formatCombinedCampaignValue($label));
-            }
-
-            $subtable = $row->getSubtable();
-            if (!empty($subtable)) {
-                $this->formatCampaignLabels($subtable);
-            }
-
-            $comparisons = $row->getComparisons();
-            if (!empty($comparisons)) {
-                $this->formatCampaignLabels($comparisons);
-            }
-        }
-
+        $dataTable->filter(FormatCampaignLabels::class);
         return $dataTable;
     }
 

--- a/API.php
+++ b/API.php
@@ -59,7 +59,7 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_ID_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -95,7 +95,7 @@ class API extends \Piwik\Plugin\API
             $dataTable          = $this->mergeDataTableMaps($dataTable, $referrersDataTable);
         }
 
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -124,14 +124,14 @@ class API extends \Piwik\Plugin\API
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_NAME_RECORD_NAME, $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable);
 
         if (!$this->isTableEmpty($dataTable)) {
-            return $dataTable;
+            return $this->formatCampaignLabels($dataTable);
         }
 
         // try to load sub table from referrers api. That might work, if the report leading to this subtable was loaded using the referrers api fallback
         $referrersDataTable = ReferrersAPI::getInstance()->getKeywordsFromCampaignId($idSite, $period, $date, $idSubtable, $segment);
 
         if (!$this->isTableEmpty($referrersDataTable)) {
-            return $this->mergeDataTableMaps($dataTable, $referrersDataTable);
+            return $this->formatCampaignLabels($this->mergeDataTableMaps($dataTable, $referrersDataTable));
         }
 
         // if we can't find a subtable report using the id, try fetching the label to search for a subtable
@@ -139,7 +139,7 @@ class API extends \Piwik\Plugin\API
         $row           = $campaignNames->getRowFromIdSubDataTable($idSubtable);
 
         if (!$row) {
-            return $dataTable;
+            return $this->formatCampaignLabels($dataTable);
         }
 
         $campaignName = $row->getColumn('label');
@@ -149,10 +149,10 @@ class API extends \Piwik\Plugin\API
 
         if ($campaignRow && $idSubtable = $campaignRow->getIdSubDataTable()) {
             $referrersDataTable = ReferrersAPI::getInstance()->getKeywordsFromCampaignId($idSite, $period, $date, $idSubtable, $segment);
-            return $this->mergeDataTableMaps($dataTable, $referrersDataTable);
+            return $this->formatCampaignLabels($this->mergeDataTableMaps($dataTable, $referrersDataTable));
         }
 
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -189,7 +189,7 @@ class API extends \Piwik\Plugin\API
             $dataTable = $this->mergeDataTableMaps($dataTable, $referrersDataTable);
         }
 
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -216,7 +216,7 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_SOURCE_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -243,7 +243,7 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_MEDIUM_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -270,7 +270,7 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_CONTENT_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -297,7 +297,7 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_GROUP_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -324,7 +324,7 @@ class API extends \Piwik\Plugin\API
     {
         $dataTable = $this->getDataTable(Archiver::CAMPAIGN_PLACEMENT_RECORD_NAME, $idSite, $period, $date, $segment);
         $dataTable->filter('AddSegmentValue');
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -352,7 +352,7 @@ class API extends \Piwik\Plugin\API
     public function getSourceMedium($idSite, $period, $date, $segment = false, $expanded = false, $flat = false)
     {
         $dataTable = $this->getDataTable(Archiver::HIERARCHICAL_SOURCE_MEDIUM_RECORD_NAME, $idSite, $period, $date, $segment, $expanded, $flat);
-        return $dataTable;
+        return $this->formatCampaignLabels($dataTable);
     }
 
     /**
@@ -378,6 +378,36 @@ class API extends \Piwik\Plugin\API
     public function getNameFromSourceMediumId($idSite, $period, $date, $idSubtable, $segment = false)
     {
         $dataTable = $this->getDataTable(Archiver::HIERARCHICAL_SOURCE_MEDIUM_RECORD_NAME, $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable);
+        return $this->formatCampaignLabels($dataTable);
+    }
+
+    private function formatCampaignLabels(DataTable\DataTableInterface $dataTable)
+    {
+        if ($dataTable instanceof DataTable\Map) {
+            foreach ($dataTable->getDataTables() as $childTable) {
+                $this->formatCampaignLabels($childTable);
+            }
+
+            return $dataTable;
+        }
+
+        foreach ($dataTable->getRows() as $row) {
+            $label = $row->getColumn('label');
+            if ($label !== false) {
+                $row->setColumn('label', MarketingCampaignsReporting::formatCombinedCampaignValue($label));
+            }
+
+            $subtable = $row->getSubtable();
+            if (!empty($subtable)) {
+                $this->formatCampaignLabels($subtable);
+            }
+
+            $comparisons = $row->getComparisons();
+            if (!empty($comparisons)) {
+                $this->formatCampaignLabels($comparisons);
+            }
+        }
+
         return $dataTable;
     }
 

--- a/Columns/CampaignSourceMedium.php
+++ b/Columns/CampaignSourceMedium.php
@@ -13,7 +13,6 @@ namespace Piwik\Plugins\MarketingCampaignsReporting\Columns;
 use Piwik\Columns\Dimension;
 use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
-use Piwik\Plugins\MarketingCampaignsReporting\Archiver;
 use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
 
 class CampaignSourceMedium extends Dimension
@@ -25,9 +24,6 @@ class CampaignSourceMedium extends Dimension
 
     public function formatValue($value, $idSite, Formatter $formatter)
     {
-        $parts = explode(Archiver::SEPARATOR_COMBINED_DIMENSIONS, (string) $value);
-        $parts = array_map([MarketingCampaignsReporting::class, 'formatCampaignValue'], $parts);
-
-        return implode(Archiver::SEPARATOR_COMBINED_DIMENSIONS, $parts);
+        return MarketingCampaignsReporting::formatCombinedCampaignValue($value);
     }
 }

--- a/Columns/CombinedKeywordContent.php
+++ b/Columns/CombinedKeywordContent.php
@@ -11,12 +11,19 @@
 namespace Piwik\Plugins\MarketingCampaignsReporting\Columns;
 
 use Piwik\Columns\Dimension;
+use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
+use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
 
 class CombinedKeywordContent extends Dimension
 {
     public function getName()
     {
         return Piwik::translate('MarketingCampaignsReporting_CombinedKeywordContent');
+    }
+
+    public function formatValue($value, $idSite, Formatter $formatter)
+    {
+        return MarketingCampaignsReporting::formatCombinedCampaignValue($value);
     }
 }

--- a/DataTable/Filter/FormatCampaignLabels.php
+++ b/DataTable/Filter/FormatCampaignLabels.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\MarketingCampaignsReporting\DataTable\Filter;
+
+use Piwik\DataTable;
+use Piwik\DataTable\BaseFilter;
+use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
+
+class FormatCampaignLabels extends BaseFilter
+{
+    public function filter($table)
+    {
+        foreach ($table->getRows() as $row) {
+            $label = $row->getColumn('label');
+            if ($label !== false) {
+                $row->setColumn('label', MarketingCampaignsReporting::formatCombinedCampaignValue($label));
+            }
+
+            $subtable = $row->getSubtable();
+            if (!empty($subtable)) {
+                $subtable->filter(static::class);
+            }
+
+            $comparisons = $row->getComparisons();
+            if (!empty($comparisons)) {
+                $comparisons->filter(static::class);
+            }
+        }
+
+        $table->setLabelsHaveChanged();
+    }
+}

--- a/DataTable/Filter/FormatCampaignLabels.php
+++ b/DataTable/Filter/FormatCampaignLabels.php
@@ -9,7 +9,6 @@
 
 namespace Piwik\Plugins\MarketingCampaignsReporting\DataTable\Filter;
 
-use Piwik\DataTable;
 use Piwik\DataTable\BaseFilter;
 use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
 

--- a/MarketingCampaignsReporting.php
+++ b/MarketingCampaignsReporting.php
@@ -158,6 +158,43 @@ class MarketingCampaignsReporting extends Plugin
         return $settingClass::formatValue($value);
     }
 
+    /**
+     * Formats labels composed of multiple campaign dimensions separated by the
+     * archive label separator.
+     *
+     * if all campaign dimensions are masked by policy, then a single placeholder
+     * value is returned, rather than several separated by SEPARATOR_COMBINED_DIMENSIONS
+     *
+     * @param mixed $value
+     */
+    public static function formatCombinedCampaignValue($value): string
+    {
+        $parts = explode(Archiver::SEPARATOR_COMBINED_DIMENSIONS, (string) $value);
+        $placeholder = self::getCampaignPlaceholderValue();
+        $nonEmptyParts = array_values(array_filter($parts, function ($part) {
+            return $part !== '';
+        }));
+
+        if (!empty($nonEmptyParts) && $placeholder !== '') {
+            $allPartsAreMasked = true;
+
+            foreach ($nonEmptyParts as $part) {
+                if ($part !== $placeholder) {
+                    $allPartsAreMasked = false;
+                    break;
+                }
+            }
+
+            if ($allPartsAreMasked) {
+                return (string) self::formatCampaignValue($placeholder);
+            }
+        }
+
+        $parts = array_map([self::class, 'formatCampaignValue'], $parts);
+
+        return implode(Archiver::SEPARATOR_COMBINED_DIMENSIONS, $parts);
+    }
+
     private static function getCampaignValuesMaskedSettingClass(): ?string
     {
         if (!class_exists(self::CAMPAIGN_VALUES_MASKED_SETTING_CLASS)) {

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -15,9 +15,9 @@ use Piwik\DataTable\Row;
 use Piwik\Db;
 use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
-use Piwik\Plugins\MarketingCampaignsReporting\API;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignName;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignSourceMedium;
+use Piwik\Plugins\MarketingCampaignsReporting\DataTable\Filter\FormatCampaignLabels;
 use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
 use Piwik\Plugins\MarketingCampaignsReporting\VisitorDetails;
 use Piwik\Plugins\Referrers\Columns\ReferrerName;
@@ -240,6 +240,32 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         );
     }
 
+    public function testFormatCombinedCampaignValueCollapsesFullyMaskedValues()
+    {
+        $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();
+        if ($placeholder === '') {
+            $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
+        }
+
+        self::assertSame(
+            Piwik::translate('PrivacyManager_CampaignParameterDiscarded'),
+            MarketingCampaignsReporting::formatCombinedCampaignValue($placeholder . ' - ' . $placeholder)
+        );
+    }
+
+    public function testFormatCombinedCampaignValuePreservesSeparatorsWhenOnlySomePartsAreMasked()
+    {
+        $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();
+        if ($placeholder === '') {
+            $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
+        }
+
+        self::assertSame(
+            Piwik::translate('PrivacyManager_CampaignParameterDiscarded') . ' - newsletter',
+            MarketingCampaignsReporting::formatCombinedCampaignValue($placeholder . ' - newsletter')
+        );
+    }
+
     public function testCampaignPlaceholderIsFormattedInCampaignReportLabels()
     {
         $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();
@@ -248,6 +274,13 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         }
 
         $expectedLabel = Piwik::translate('PrivacyManager_CampaignParameterDiscarded');
+        $comparisons = new DataTable();
+        $comparisons->addRow(new Row([
+            Row::COLUMNS => [
+                'label' => $placeholder . ' - newsletter',
+            ],
+        ]));
+
         $subtable = new DataTable();
         $subtable->addRow(new Row([
             Row::COLUMNS => [
@@ -262,15 +295,18 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
             ],
             Row::DATATABLE_ASSOCIATED => $subtable,
         ]));
+        $table->getFirstRow()->setComparisons($comparisons);
 
-        $method = new \ReflectionMethod(API::class, 'formatCampaignLabels');
-        $method->setAccessible(true);
-        $method->invoke(API::getInstance(), $table);
+        $table->filter(FormatCampaignLabels::class);
 
         self::assertSame($expectedLabel, $table->getFirstRow()->getColumn('label'));
         self::assertSame(
             $expectedLabel,
             $table->getFirstRow()->getSubtable()->getFirstRow()->getColumn('label')
+        );
+        self::assertSame(
+            $expectedLabel . ' - newsletter',
+            $table->getFirstRow()->getComparisons()->getFirstRow()->getColumn('label')
         );
     }
 

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -10,10 +10,12 @@
 namespace Piwik\Plugins\MarketingCampaignsReporting\tests\Integration;
 
 use Piwik\Common;
-use Piwik\Date;
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
 use Piwik\Db;
 use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
+use Piwik\Plugins\MarketingCampaignsReporting\API;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignName;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignSourceMedium;
 use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
@@ -233,8 +235,42 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
             (new ReferrerName())->formatValue($placeholder, $this->idSite, $formatter)
         );
         self::assertSame(
-            $expectedLabel . ' - ' . $expectedLabel,
+            $expectedLabel,
             (new CampaignSourceMedium())->formatValue($placeholder . ' - ' . $placeholder, $this->idSite, $formatter)
+        );
+    }
+
+    public function testCampaignPlaceholderIsFormattedInCampaignReportLabels()
+    {
+        $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();
+        if ($placeholder === '') {
+            $this->markTestSkipped('CampaignParameterValuesMasked is not available in this core version.');
+        }
+
+        $expectedLabel = Piwik::translate('PrivacyManager_CampaignParameterDiscarded');
+        $subtable = new DataTable();
+        $subtable->addRow(new Row([
+            Row::COLUMNS => [
+                'label' => $placeholder . ' - ' . $placeholder,
+            ],
+        ]));
+
+        $table = new DataTable();
+        $table->addRow(new Row([
+            Row::COLUMNS => [
+                'label' => $placeholder,
+            ],
+            Row::DATATABLE_ASSOCIATED => $subtable,
+        ]));
+
+        $method = new \ReflectionMethod(API::class, 'formatCampaignLabels');
+        $method->setAccessible(true);
+        $method->invoke(API::getInstance(), $table);
+
+        self::assertSame($expectedLabel, $table->getFirstRow()->getColumn('label'));
+        self::assertSame(
+            $expectedLabel,
+            $table->getFirstRow()->getSubtable()->getFirstRow()->getColumn('label')
         );
     }
 


### PR DESCRIPTION
## Description

Masking for campaign reports when CNIL is enabled is not properly formatted. This fix addresses this and now correctly runs the datatables through a formatter.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA]Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✖] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
