### PR TITLE
Adds code to fallback to _rcn / _rck when no campaign_* values are found on the visit or current URL, #L3-1085

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Test/UI/processed-ui-screenshots/
 /tests/System/processed/
 /tests/UI/processed-ui-screenshots/
+.codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### 5.2.1 - 2026-05-25
+- Added code tp fallback to _rcn / _rck when no campaign_* values are found on the visit or current URL
+
 #### 5.2.0 - 2026-05-11
 - added support for campaign masking via CNIL policy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 #### 5.2.1 - 2026-05-25
-- Added code tp fallback to _rcn / _rck when no campaign_* values are found on the visit or current URL
+- Added code to fallback to _rcn / _rck when no campaign_* values are found on the visit or current URL
 
 #### 5.2.0 - 2026-05-11
 - added support for campaign masking via CNIL policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-#### 5.2.1 - 2026-05-25
+#### 5.2.1 - 2026-05-26
 - Added code to fallback to _rcn / _rck when no campaign_* values are found on the visit or current URL
 
 #### 5.2.0 - 2026-05-11

--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -92,25 +92,33 @@ abstract class Base extends VisitDimension
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
+        $campaignDimensions = [];
+
         // @todo Not using Common::REFERRER_TYPE_AI_ASSISTANT for BC reasons. Can be changed with Matomo 6
-        if ($visitProperties['referer_type'] === 8) {
-            return null; // skip campaign detection when a AI assistant was detected as referrer by core
-        }
-
-        $campaignDimensions = $campaignDetector->detectCampaignFromVisit(
-            $visitProperties,
-            $campaignParameters
-        );
-        $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
-            $campaignDimensions,
-            (int) $request->getIdSiteIfExists()
-        );
-
-        if (empty($campaignDimensions)) {
-            $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
-                $request,
+        if ($visitProperties['referer_type'] !== 8) {
+            $campaignDimensions = $campaignDetector->detectCampaignFromVisit(
+                $visitProperties,
                 $campaignParameters
             );
+            $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+                $campaignDimensions,
+                (int) $request->getIdSiteIfExists()
+            );
+
+            if (empty($campaignDimensions)) {
+                $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
+                    $request,
+                    $campaignParameters
+                );
+                $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+                    $campaignDimensions,
+                    (int) $request->getIdSiteIfExists()
+                );
+            }
+        }
+
+        if (empty($campaignDimensions)) {
+            $campaignDimensions = $this->getCampaignDimensionsFromReferrerAttributionCookie($request);
             $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
                 $campaignDimensions,
                 (int) $request->getIdSiteIfExists()
@@ -122,6 +130,30 @@ abstract class Base extends VisitDimension
         }
 
         return null;
+    }
+
+    private function getCampaignDimensionsFromReferrerAttributionCookie(Request $request): array
+    {
+        $campaignName = $this->getReferrerCampaignQueryParam($request, '_rcn');
+        if ($campaignName === '') {
+            return [];
+        }
+
+        $campaignDimensions = [
+            (new CampaignName())->getColumnName() => $campaignName,
+        ];
+
+        $campaignKeyword = $this->getReferrerCampaignQueryParam($request, '_rck');
+        if ($campaignKeyword !== '') {
+            $campaignDimensions[(new CampaignKeyword())->getColumnName()] = $campaignKeyword;
+        }
+
+        return $campaignDimensions;
+    }
+
+    private function getReferrerCampaignQueryParam(Request $request, string $paramName): string
+    {
+        return trim(urldecode($request->getParam($paramName)));
     }
 
     public function formatValue($value, $idSite, Formatter $formatter)

--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -15,6 +15,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Metrics\Formatter;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
+use Piwik\Plugins\MarketingCampaignsReporting\SystemSettings;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
@@ -92,23 +93,20 @@ abstract class Base extends VisitDimension
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
-        // @todo Not using Common::REFERRER_TYPE_AI_ASSISTANT for BC reasons. Can be changed with Matomo 6
-        if ($visitProperties['referer_type'] === 8) {
-            return null; // skip campaign detection when a AI assistant was detected as referrer by core
-        }
-
-        $campaignDimensions = $campaignDetector->detectCampaignFromVisit(
-            $visitProperties,
-            $campaignParameters
-        );
+        $campaignDimensions = $this->getCampaignDimensionsFromReferrerAttributionCookie($request);
         $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
             $campaignDimensions,
             (int) $request->getIdSiteIfExists()
         );
 
+        // @todo Not using Common::REFERRER_TYPE_AI_ASSISTANT for BC reasons. Can be changed with Matomo 6
+        if (empty($campaignDimensions) && $visitProperties['referer_type'] === 8) {
+            return null; // skip campaign detection when a AI assistant was detected as referrer by core
+        }
+
         if (empty($campaignDimensions)) {
-            $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
-                $request,
+            $campaignDimensions = $campaignDetector->detectCampaignFromVisit(
+                $visitProperties,
                 $campaignParameters
             );
             $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
@@ -116,8 +114,12 @@ abstract class Base extends VisitDimension
                 (int) $request->getIdSiteIfExists()
             );
         }
+
         if (empty($campaignDimensions)) {
-            $campaignDimensions = $this->getCampaignDimensionsFromReferrerAttributionCookie($request);
+            $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
+                $request,
+                $campaignParameters
+            );
             $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
                 $campaignDimensions,
                 (int) $request->getIdSiteIfExists()
@@ -152,7 +154,20 @@ abstract class Base extends VisitDimension
 
     private function getReferrerCampaignQueryParam(Request $request, string $paramName): string
     {
-        return trim(urldecode($request->getParam($paramName)));
+        $value = trim(urldecode($request->getParam($paramName)));
+
+        if ($value !== '' && $this->shouldLowerCampaignCase()) {
+            $value = mb_strtolower($value);
+        }
+
+        return $value;
+    }
+
+    private function shouldLowerCampaignCase(): bool
+    {
+        $systemSettings = StaticContainer::get(SystemSettings::class);
+
+        return !$systemSettings->doNotChangeCaseOfUtmParameters->getValue();
     }
 
     public function formatValue($value, $idSite, Formatter $formatter)

--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -92,36 +92,36 @@ abstract class Base extends VisitDimension
 
         $visitProperties = $visitor->visitProperties->getProperties();
 
-        $campaignDimensions = [];
-
         // @todo Not using Common::REFERRER_TYPE_AI_ASSISTANT for BC reasons. Can be changed with Matomo 6
-        if ($visitProperties['referer_type'] !== 8) {
-            $campaignDimensions = $campaignDetector->detectCampaignFromVisit(
-                $visitProperties,
+        if ($visitProperties['referer_type'] === 8) {
+            return null; // skip campaign detection when a AI assistant was detected as referrer by core
+        }
+
+        $campaignDimensions = $campaignDetector->detectCampaignFromVisit(
+            $visitProperties,
+            $campaignParameters
+        );
+        $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+            $campaignDimensions,
+            (int) $request->getIdSiteIfExists()
+        );
+
+        if (empty($campaignDimensions)) {
+            $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
+                $request,
                 $campaignParameters
             );
             $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
                 $campaignDimensions,
                 (int) $request->getIdSiteIfExists()
             );
-
-            if (empty($campaignDimensions)) {
-                $campaignDimensions = $campaignDetector->detectCampaignFromRequest(
-                    $request,
-                    $campaignParameters
-                );
-                $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
-                    $campaignDimensions,
-                    (int) $request->getIdSiteIfExists()
-                );
-            }
-            if (empty($campaignDimensions)) {
-                $campaignDimensions = $this->getCampaignDimensionsFromReferrerAttributionCookie($request);
-                $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
-                    $campaignDimensions,
-                    (int) $request->getIdSiteIfExists()
-                );
-            }
+        }
+        if (empty($campaignDimensions)) {
+            $campaignDimensions = $this->getCampaignDimensionsFromReferrerAttributionCookie($request);
+            $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+                $campaignDimensions,
+                (int) $request->getIdSiteIfExists()
+            );
         }
 
         if (!empty($campaignDimensions) && array_key_exists($this->getColumnName(), $campaignDimensions)) {

--- a/Columns/Base.php
+++ b/Columns/Base.php
@@ -115,14 +115,13 @@ abstract class Base extends VisitDimension
                     (int) $request->getIdSiteIfExists()
                 );
             }
-        }
-
-        if (empty($campaignDimensions)) {
-            $campaignDimensions = $this->getCampaignDimensionsFromReferrerAttributionCookie($request);
-            $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
-                $campaignDimensions,
-                (int) $request->getIdSiteIfExists()
-            );
+            if (empty($campaignDimensions)) {
+                $campaignDimensions = $this->getCampaignDimensionsFromReferrerAttributionCookie($request);
+                $campaignDimensions = $this->normalizeDetectedCampaignDimensions(
+                    $campaignDimensions,
+                    (int) $request->getIdSiteIfExists()
+                );
+            }
         }
 
         if (!empty($campaignDimensions) && array_key_exists($this->getColumnName(), $campaignDimensions)) {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "MarketingCampaignsReporting",
     "description": "Measure the effectiveness of your marketing campaigns. New reports, segments & track up to five channels: campaign, source, medium, keyword, content.",
-    "version": "5.2.0",
+    "version": "5.2.1",
     "keywords": ["Campaign", "Marketing", "Channels", "UTM tags"],
     "license": "GPL v3+",
     "homepage": "https://matomo.org",

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -257,6 +257,51 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         self::assertSame('Campaign Keyword', $conversion['campaign_keyword']);
     }
 
+    public function testGoalConversionSkipsReferrerAttributionCampaignCookieForAiAssistants()
+    {
+        if (version_compare(Version::VERSION, '5.5.0-b1', '<')) {
+            $this->markTestSkipped('AI assistant referrer detection is not available in this core version.');
+        }
+
+        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_visit'));
+        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_conversion'));
+
+        $idGoal = \Piwik\Plugins\Goals\API::getInstance()->addGoal(
+            $this->idSite,
+            'manual goal',
+            'manually',
+            '',
+            'contains'
+        );
+
+        $tracker = Fixture::getTracker(
+            $this->idSite,
+            date('Y-m-d H:i:s'),
+            $defaultInit = true,
+            $useLocal = false
+        );
+
+        $tracker->setUrl('https://www.example.com/landing-page');
+        $tracker->setUrlReferrer('https://chatgpt.com/');
+        Fixture::checkResponse($tracker->doTrackPageView('Some page title'));
+
+        $tracker->setUrl('https://www.example.com/conversion-page');
+        $tracker->setCustomTrackingParameter('_rcn', 'Campaign Name');
+        $tracker->setCustomTrackingParameter('_rck', 'Campaign Keyword');
+        Fixture::checkResponse($tracker->doTrackGoal($idGoal, 42));
+
+        $conversion = Db::fetchRow(
+            'SELECT referer_type, referer_name, referer_keyword, campaign_name, campaign_keyword FROM '
+            . Common::prefixTable('log_conversion')
+            . ' LIMIT 1'
+        );
+
+        self::assertSame(Common::REFERRER_TYPE_AI_ASSISTANT, (int) $conversion['referer_type']);
+        self::assertSame('ChatGPT', $conversion['referer_name']);
+        self::assertEmpty($conversion['campaign_name']);
+        self::assertEmpty($conversion['campaign_keyword']);
+    }
+
     public function testCampaignPlaceholderIsFormattedForReports()
     {
         $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\MarketingCampaignsReporting\tests\Integration;
 
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\Db;
@@ -19,6 +20,7 @@ use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignName;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignSourceMedium;
 use Piwik\Plugins\MarketingCampaignsReporting\DataTable\Filter\FormatCampaignLabels;
 use Piwik\Plugins\MarketingCampaignsReporting\MarketingCampaignsReporting;
+use Piwik\Plugins\MarketingCampaignsReporting\SystemSettings;
 use Piwik\Plugins\MarketingCampaignsReporting\VisitorDetails;
 use Piwik\Plugins\Referrers\Columns\ReferrerName;
 use Piwik\Policy\CnilPolicy;
@@ -46,6 +48,7 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         parent::setUp();
 
         $this->idSite = Fixture::createWebsite('2016-01-01 00:00:01', 0, 'TestSite', 'https://example.com');
+        $this->setDoNotChangeCaseOfUtmParameters(true);
     }
 
     /**
@@ -218,6 +221,8 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
 
     public function testGoalConversionUsesReferrerAttributionCampaignCookie()
     {
+        $this->setDoNotChangeCaseOfUtmParameters(false);
+
         Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_visit'));
         Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_conversion'));
 
@@ -253,8 +258,63 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         self::assertSame(Common::REFERRER_TYPE_CAMPAIGN, (int) $conversion['referer_type']);
         self::assertSame('campaign name', $conversion['referer_name']);
         self::assertSame('campaign keyword', $conversion['referer_keyword']);
-        self::assertSame('Campaign Name', $conversion['campaign_name']);
-        self::assertSame('Campaign Keyword', $conversion['campaign_keyword']);
+        self::assertSame('campaign name', $conversion['campaign_name']);
+        self::assertSame('campaign keyword', $conversion['campaign_keyword']);
+    }
+
+    public function testGoalConversionUsesReferrerAttributionCampaignCookieForAIAssistantVisit()
+    {
+        if (version_compare(Version::VERSION, '5.5.0-b1', '<')) {
+            $this->markTestSkipped('AI assistant referrer type is not available in this core version.');
+        }
+
+        $this->setDoNotChangeCaseOfUtmParameters(false);
+
+        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_visit'));
+        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_conversion'));
+
+        $idGoal = \Piwik\Plugins\Goals\API::getInstance()->addGoal(
+            $this->idSite,
+            'manual goal',
+            'manually',
+            '',
+            'contains'
+        );
+
+        $tracker = Fixture::getTracker(
+            $this->idSite,
+            date('Y-m-d H:i:s'),
+            $defaultInit = true,
+            $useLocal = false
+        );
+
+        $tracker->setUrl('https://www.example.com/landing-page');
+        $tracker->setUrlReferrer('https://chatgpt.com/');
+        Fixture::checkResponse($tracker->doTrackPageView('Some page title'));
+
+        $visit = Db::fetchRow(
+            'SELECT referer_type FROM '
+            . Common::prefixTable('log_visit')
+            . ' LIMIT 1'
+        );
+        self::assertSame(Common::REFERRER_TYPE_AI_ASSISTANT, (int) $visit['referer_type']);
+
+        $tracker->setUrl('https://www.example.com/conversion-page');
+        $tracker->setCustomTrackingParameter('_rcn', 'Campaign Name');
+        $tracker->setCustomTrackingParameter('_rck', 'Campaign Keyword');
+        Fixture::checkResponse($tracker->doTrackGoal($idGoal, 42));
+
+        $conversion = Db::fetchRow(
+            'SELECT referer_type, referer_name, referer_keyword, campaign_name, campaign_keyword FROM '
+            . Common::prefixTable('log_conversion')
+            . ' LIMIT 1'
+        );
+
+        self::assertSame(Common::REFERRER_TYPE_CAMPAIGN, (int) $conversion['referer_type']);
+        self::assertSame('campaign name', $conversion['referer_name']);
+        self::assertSame('campaign keyword', $conversion['referer_keyword']);
+        self::assertSame('campaign name', $conversion['campaign_name']);
+        self::assertSame('campaign keyword', $conversion['campaign_keyword']);
     }
 
     public function testCampaignPlaceholderIsFormattedForReports()
@@ -383,5 +443,13 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         self::assertSame($expectedLabel, $visitor['campaignSource']);
         self::assertSame($expectedLabel, $visitor['campaignGroup']);
         self::assertSame($expectedLabel, $visitor['campaignPlacement']);
+    }
+
+    private function setDoNotChangeCaseOfUtmParameters(bool $value): void
+    {
+        $systemSettings = StaticContainer::get(SystemSettings::class);
+        $systemSettings->doNotChangeCaseOfUtmParameters->setIsWritableByCurrentUser(true);
+        $systemSettings->doNotChangeCaseOfUtmParameters->setValue($value);
+        $systemSettings->save();
     }
 }

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -257,51 +257,6 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         self::assertSame('Campaign Keyword', $conversion['campaign_keyword']);
     }
 
-    public function testGoalConversionSkipsReferrerAttributionCampaignCookieForAiAssistants()
-    {
-        if (version_compare(Version::VERSION, '5.5.0-b1', '<')) {
-            $this->markTestSkipped('AI assistant referrer detection is not available in this core version.');
-        }
-
-        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_visit'));
-        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_conversion'));
-
-        $idGoal = \Piwik\Plugins\Goals\API::getInstance()->addGoal(
-            $this->idSite,
-            'manual goal',
-            'manually',
-            '',
-            'contains'
-        );
-
-        $tracker = Fixture::getTracker(
-            $this->idSite,
-            date('Y-m-d H:i:s'),
-            $defaultInit = true,
-            $useLocal = false
-        );
-
-        $tracker->setUrl('https://www.example.com/landing-page');
-        $tracker->setUrlReferrer('https://chatgpt.com/');
-        Fixture::checkResponse($tracker->doTrackPageView('Some page title'));
-
-        $tracker->setUrl('https://www.example.com/conversion-page');
-        $tracker->setCustomTrackingParameter('_rcn', 'Campaign Name');
-        $tracker->setCustomTrackingParameter('_rck', 'Campaign Keyword');
-        Fixture::checkResponse($tracker->doTrackGoal($idGoal, 42));
-
-        $conversion = Db::fetchRow(
-            'SELECT referer_type, referer_name, referer_keyword, campaign_name, campaign_keyword FROM '
-            . Common::prefixTable('log_conversion')
-            . ' LIMIT 1'
-        );
-
-        self::assertSame(Common::REFERRER_TYPE_AI_ASSISTANT, (int) $conversion['referer_type']);
-        self::assertSame('ChatGPT', $conversion['referer_name']);
-        self::assertEmpty($conversion['campaign_name']);
-        self::assertEmpty($conversion['campaign_keyword']);
-    }
-
     public function testCampaignPlaceholderIsFormattedForReports()
     {
         $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();

--- a/tests/Integration/CorrectCampaignDetectionTest.php
+++ b/tests/Integration/CorrectCampaignDetectionTest.php
@@ -216,6 +216,47 @@ class CorrectCampaignDetectionTest extends IntegrationTestCase
         }
     }
 
+    public function testGoalConversionUsesReferrerAttributionCampaignCookie()
+    {
+        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_visit'));
+        Db::query('TRUNCATE TABLE ' . Common::prefixTable('log_conversion'));
+
+        $idGoal = \Piwik\Plugins\Goals\API::getInstance()->addGoal(
+            $this->idSite,
+            'manual goal',
+            'manually',
+            '',
+            'contains'
+        );
+
+        $tracker = Fixture::getTracker(
+            $this->idSite,
+            date('Y-m-d H:i:s'),
+            $defaultInit = true,
+            $useLocal = false
+        );
+
+        $tracker->setUrl('https://www.example.com/landing-page');
+        Fixture::checkResponse($tracker->doTrackPageView('Some page title'));
+
+        $tracker->setUrl('https://www.example.com/conversion-page');
+        $tracker->setCustomTrackingParameter('_rcn', 'Campaign Name');
+        $tracker->setCustomTrackingParameter('_rck', 'Campaign Keyword');
+        Fixture::checkResponse($tracker->doTrackGoal($idGoal, 42));
+
+        $conversion = Db::fetchRow(
+            'SELECT referer_type, referer_name, referer_keyword, campaign_name, campaign_keyword FROM '
+            . Common::prefixTable('log_conversion')
+            . ' LIMIT 1'
+        );
+
+        self::assertSame(Common::REFERRER_TYPE_CAMPAIGN, (int) $conversion['referer_type']);
+        self::assertSame('campaign name', $conversion['referer_name']);
+        self::assertSame('campaign keyword', $conversion['referer_keyword']);
+        self::assertSame('Campaign Name', $conversion['campaign_name']);
+        self::assertSame('Campaign Keyword', $conversion['campaign_keyword']);
+    }
+
     public function testCampaignPlaceholderIsFormattedForReports()
     {
         $placeholder = MarketingCampaignsReporting::getCampaignPlaceholderValue();


### PR DESCRIPTION
## Description
Adds code to fallback to _rcn / _rck when no campaign_* values are found on the visit or current URL

## Issue No
#L3-1085

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
