### PR TITLE
Add PHPStan CI check and pre-push hook, PG-4897 [no_release]

### DIFF
--- a/.git-hooks-matomo/pre-push
+++ b/.git-hooks-matomo/pre-push
@@ -56,52 +56,59 @@ fi
 # Basic setup
 cd "$REPO_DIR"
 STATUS=0
-
-
-
-
-### Resolve the base to diff against. ###
-
-# Use the merge base with the remote main branch: the local branch can be stale
-# or missing, which silently widens the diff to files the push doesn't touch.
 MAIN_BRANCH='5.x-dev'
-DIFF_BASE=$(git merge-base HEAD "origin/${MAIN_BRANCH}" 2>/dev/null)
-if [[ -z "$DIFF_BASE" ]]; then
-  echo "Could not resolve the merge base between HEAD and origin/${MAIN_BRANCH}."
-  echo "Run 'git fetch origin ${MAIN_BRANCH}' and push again."
-  exit 1
-fi
-
-
-
-### Run PHPStan on newly created files. ###
-
+ZERO_OID='0000000000000000000000000000000000000000'
 PHPSTAN_CREATED_CONFIG=phpstan/phpstan.created.neon
-if [[ -f "$PHPSTAN_CREATED_CONFIG" ]]; then
-  CHANGED_FILES=$(git diff --name-only ${DIFF_BASE} HEAD --diff-filter=A | grep '\.php$' || true)
-  if [ -z "$CHANGED_FILES" ]; then
-    echo "No created PHP files"
-  else
-    echo "Running PHPstan at a very high level on new files"
-    CHANGED_FILES=`echo "$CHANGED_FILES" | sed -e 's/^\(.*\)$/"\1"/' | xargs -I{} echo "${PLUGIN_PATH}{}"`
-    echo "$CHANGED_FILES" | xargs $COMMAND analyse -c ${PLUGIN_PATH}${PHPSTAN_CREATED_CONFIG} || STATUS=1
-  fi
-fi
-
-
-
-### Run PHPStan on modified files. ###
 PHPSTAN_MODIFIED_CONFIG=phpstan/phpstan.modified.neon
-if [[ -f "$PHPSTAN_MODIFIED_CONFIG" ]]; then
-  CHANGED_FILES=$(git diff --name-only ${DIFF_BASE} HEAD --diff-filter=CM | grep '\.php$' || true)
-  if [ -z "$CHANGED_FILES" ]; then
-    echo "No changed PHP files"
-  else
-    echo "Running PHPstan on modified files"
-    CHANGED_FILES=`echo "$CHANGED_FILES" | sed -e 's/^\(.*\)$/"\1"/' | xargs -I{} echo "${PLUGIN_PATH}{}"`
-    echo "$CHANGED_FILES" | xargs $COMMAND analyse -c ${PLUGIN_PATH}${PHPSTAN_MODIFIED_CONFIG} || STATUS=1
+
+
+
+### Run PHPStan on the files a pushed commit adds or changes. ###
+
+# $1 -- the pushed commit
+# $2 -- git diff filter (A for created files, CM for modified files)
+# $3 -- the phpstan config to use
+# $4 -- log label for the file kind
+check_pushed_commit() {
+  local commit="$1" filter="$2" config="$3" label="$4"
+
+  if [[ ! -f "$config" ]]; then
+    return 0
   fi
-fi
+
+  # Use the merge base with the remote main branch: the local branch can be stale
+  # or missing, which silently widens the diff to files the push doesn't touch.
+  local diff_base
+  diff_base=$(git merge-base "$commit" "origin/${MAIN_BRANCH}" 2>/dev/null)
+  if [[ -z "$diff_base" ]]; then
+    echo "Could not resolve the merge base between ${commit} and origin/${MAIN_BRANCH}."
+    echo "Run 'git fetch origin ${MAIN_BRANCH}' and push again."
+    return 1
+  fi
+
+  local changed_files
+  changed_files=$(git diff --name-only "$diff_base" "$commit" --diff-filter="$filter" | grep '\.php$' || true)
+  if [ -z "$changed_files" ]; then
+    echo "No ${label} PHP files"
+    return 0
+  fi
+
+  echo "Running PHPstan on ${label} files"
+  changed_files=`echo "$changed_files" | sed -e 's/^\(.*\)$/"\1"/' | xargs -I{} echo "${PLUGIN_PATH}{}"`
+  echo "$changed_files" | xargs $COMMAND analyse -c ${PLUGIN_PATH}${config} || return 1
+}
+
+# Check the commits actually being pushed, as supplied on stdin: HEAD is wrong
+# when pushing another local branch or several refs at once. The inner commands
+# read /dev/null so they cannot consume the remaining stdin lines.
+while read -r local_ref local_oid remote_ref remote_oid; do
+  if [[ "$local_oid" == "$ZERO_OID" ]]; then
+    continue # deleting the remote ref, nothing is pushed
+  fi
+  echo "Checking ${local_ref} (${local_oid})"
+  check_pushed_commit "$local_oid" A "$PHPSTAN_CREATED_CONFIG" "created" < /dev/null || STATUS=1
+  check_pushed_commit "$local_oid" CM "$PHPSTAN_MODIFIED_CONFIG" "modified" < /dev/null || STATUS=1
+done
 
 # Don't bother running the full check, as we check changes files already, and
 # can assume that the unchanged files don't need rechecking.

--- a/.git-hooks-matomo/pre-push
+++ b/.git-hooks-matomo/pre-push
@@ -22,8 +22,8 @@ echo "Running pre-push hook in repo: $REPO_DIR"
 if [[ "$REPO_DIR" =~ /plugins/(.*) ]]; then
     PLUGIN_PATH="plugins/${BASH_REMATCH[1]}/"
 else
-    echo "Not a plugin, not running any further checks"
-    exit 1
+    echo "Not inside a Matomo checkout's plugins/ directory, skipping PHPStan checks"
+    exit 0
 fi
 MATOMO_DIR=$(echo "$REPO_DIR" | sed -E 's|/plugins/.*$||')
 

--- a/.git-hooks-matomo/pre-push
+++ b/.git-hooks-matomo/pre-push
@@ -17,7 +17,7 @@
 ### Check we're running in the context of a plugin and get helpful dir variables ###
 
 REPO_DIR="$(git rev-parse --show-toplevel)"
-echo "Running pre-commit hook in repo: $REPO_DIR"
+echo "Running pre-push hook in repo: $REPO_DIR"
 
 if [[ "$REPO_DIR" =~ /plugins/(.*) ]]; then
     PLUGIN_PATH="plugins/${BASH_REMATCH[1]}/"
@@ -78,7 +78,7 @@ fi
 
 PHPSTAN_CREATED_CONFIG=phpstan/phpstan.created.neon
 if [[ -f "$PHPSTAN_CREATED_CONFIG" ]]; then
-  CHANGED_FILES=$(git diff --name-only ${DIFF_BASE} --diff-filter=A | grep '\.php$' || true)
+  CHANGED_FILES=$(git diff --name-only ${DIFF_BASE} HEAD --diff-filter=A | grep '\.php$' || true)
   if [ -z "$CHANGED_FILES" ]; then
     echo "No created PHP files"
   else
@@ -93,7 +93,7 @@ fi
 ### Run PHPStan on modified files. ###
 PHPSTAN_MODIFIED_CONFIG=phpstan/phpstan.modified.neon
 if [[ -f "$PHPSTAN_MODIFIED_CONFIG" ]]; then
-  CHANGED_FILES=$(git diff --name-only ${DIFF_BASE} --diff-filter=CM | grep '\.php$' || true)
+  CHANGED_FILES=$(git diff --name-only ${DIFF_BASE} HEAD --diff-filter=CM | grep '\.php$' || true)
   if [ -z "$CHANGED_FILES" ]; then
     echo "No changed PHP files"
   else

--- a/.git-hooks-matomo/pre-push
+++ b/.git-hooks-matomo/pre-push
@@ -31,22 +31,33 @@ MATOMO_DIR=$(echo "$REPO_DIR" | sed -E 's|/plugins/.*$||')
 
 ### Figure out how to run PHPStan - ddev or not. ###
 
-COMMAND=""
+COMMAND=()
 # Use local PHP if setup
 if command -v php >/dev/null 2>&1 && [ -f "${MATOMO_DIR}/vendor/bin/phpstan" ]; then
-    COMMAND="${MATOMO_DIR}/vendor/bin/phpstan"
+    COMMAND=("${MATOMO_DIR}/vendor/bin/phpstan")
     PLUGIN_PATH=''
 elif command -v ddev >/dev/null 2>&1; then
-  # Use ddev if setup (overridding local setup)
+  # Fall back to ddev when there is no local PHPStan. Local takes priority: it is faster,
+  # and it is what the elif above actually encodes.
   if [ -d "$MATOMO_DIR/.ddev" ]; then
     cd "$MATOMO_DIR" || exit 1
-    if ddev status 2>&1 > /dev/null; then
-      COMMAND="ddev exec phpstan"
+    # `ddev status` exits 0 for a stopped project, so its exit code says nothing about whether
+    # the containers are up. `ddev describe -j` reports the real state.
+    if [[ "$(ddev describe -j 2>/dev/null | sed -n 's/.*"status":"\([a-z]*\)".*/\1/p' | head -1)" == "running" ]]; then
+      COMMAND=(ddev exec phpstan)
+    else
+      DDEV_STOPPED=1
     fi
   fi
 fi
 # If no command, exit
-if [[ -z "$COMMAND" ]]; then
+if [[ ${#COMMAND[@]} -eq 0 ]]; then
+  if [[ "${DDEV_STOPPED:-0}" -eq 1 ]]; then
+    # The tooling exists and simply is not started. Blocking the push here teaches people to
+    # reach for --no-verify, which is worse than skipping one check.
+    echo "ddev is not running, so PHPStan was skipped. Run 'ddev start' to check before pushing."
+    exit 0
+  fi
   echo "No way to run phpstan found."
   exit 1
 fi
@@ -54,9 +65,37 @@ fi
 
 
 # Basic setup
-cd "$REPO_DIR"
+cd "$REPO_DIR" || exit 1
 STATUS=0
-MAIN_BRANCH='5.x-dev'
+# The branch to diff against is the remote's default, not a fixed name: plugins on
+# 6.x-dev would otherwise be compared against 5.x-dev and diff the wrong files.
+# origin/HEAD is only set if the clone recorded it, so fall back to asking the remote,
+# then to 5.x-dev for a clone that can reach neither.
+MAIN_BRANCH=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+if [[ -z "$MAIN_BRANCH" ]]; then
+  MAIN_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+fi
+MAIN_BRANCH=${MAIN_BRANCH:-5.x-dev}
+
+# PHPStan analyses the plugin against whichever Matomo checkout happens to contain it, which is not
+# necessarily the major this branch targets. A 6.x-dev branch sitting in a Matomo 5 checkout is
+# analysed against Matomo 5, and the findings look entirely real -- correct files, correct line
+# numbers -- for signatures that simply differ between the majors. Warn rather than fail: the
+# mismatch is sometimes deliberate, and a hard failure on a guess is what teaches --no-verify.
+CORE_VERSION_FILE="$MATOMO_DIR/core/Version.php"
+if [ -f "$CORE_VERSION_FILE" ]; then
+  CORE_MAJOR=$(sed -n "s/.*const VERSION = '\([0-9]\{1,\}\)\..*/\1/p" "$CORE_VERSION_FILE" | head -1)
+  # Only `<major>.x-dev` says anything about the target major; any other branch name is left alone.
+  BRANCH_MAJOR=$(printf '%s' "$MAIN_BRANCH" | sed -n 's/^\([0-9]\{1,\}\)\.x-dev$/\1/p')
+  if [ -n "$CORE_MAJOR" ] && [ -n "$BRANCH_MAJOR" ] && [ "$CORE_MAJOR" != "$BRANCH_MAJOR" ]; then
+    echo
+    echo "WARNING: analysing against Matomo ${CORE_MAJOR}.x in $MATOMO_DIR, but this plugin's"
+    echo "         default branch is $MAIN_BRANCH. Findings below may not match CI, which"
+    echo "         analyses against Matomo ${BRANCH_MAJOR}.x. Check a finding against a Matomo"
+    echo "         ${BRANCH_MAJOR}.x checkout before acting on it."
+    echo
+  fi
+fi
 ZERO_OID='0000000000000000000000000000000000000000'
 PHPSTAN_CREATED_CONFIG=phpstan/phpstan.created.neon
 PHPSTAN_MODIFIED_CONFIG=phpstan/phpstan.modified.neon
@@ -66,7 +105,8 @@ PHPSTAN_MODIFIED_CONFIG=phpstan/phpstan.modified.neon
 ### Run PHPStan on the files a pushed commit adds or changes. ###
 
 # $1 -- the pushed commit
-# $2 -- git diff filter (A for created files, CM for modified files)
+# $2 -- git diff filter (A for created files, CMR for modified files; R matters because a
+#       renamed-and-modified file has status R and would otherwise skip the check)
 # $3 -- the phpstan config to use
 # $4 -- log label for the file kind
 check_pushed_commit() {
@@ -86,28 +126,35 @@ check_pushed_commit() {
     return 1
   fi
 
-  local changed_files
-  changed_files=$(git diff --name-only "$diff_base" "$commit" --diff-filter="$filter" | grep '\.php$' || true)
-  if [ -z "$changed_files" ]; then
+  # Read NUL-delimited so a path containing a space stays one argument. Quoting the paths and
+  # piping through xargs does not: xargs strips the quotes it was given, then splits on the space.
+  local changed_files=()
+  local file
+  while IFS= read -r -d '' file; do
+    [[ "$file" == *.php ]] && changed_files+=("${PLUGIN_PATH}${file}")
+  done < <(git diff --name-only -z "$diff_base" "$commit" --diff-filter="$filter")
+
+  if [[ ${#changed_files[@]} -eq 0 ]]; then
     echo "No ${label} PHP files"
     return 0
   fi
 
   echo "Running PHPstan on ${label} files"
-  changed_files=`echo "$changed_files" | sed -e 's/^\(.*\)$/"\1"/' | xargs -I{} echo "${PLUGIN_PATH}{}"`
-  echo "$changed_files" | xargs $COMMAND analyse -c ${PLUGIN_PATH}${config} || return 1
+  "${COMMAND[@]}" analyse -c "${PLUGIN_PATH}${config}" "${changed_files[@]}" || return 1
 }
 
 # Check the commits actually being pushed, as supplied on stdin: HEAD is wrong
 # when pushing another local branch or several refs at once. The inner commands
 # read /dev/null so they cannot consume the remaining stdin lines.
+# shellcheck disable=SC2034 # remote_ref/remote_oid consume git's 4-field pre-push line
 while read -r local_ref local_oid remote_ref remote_oid; do
   if [[ "$local_oid" == "$ZERO_OID" ]]; then
     continue # deleting the remote ref, nothing is pushed
   fi
   echo "Checking ${local_ref} (${local_oid})"
   check_pushed_commit "$local_oid" A "$PHPSTAN_CREATED_CONFIG" "created" < /dev/null || STATUS=1
-  check_pushed_commit "$local_oid" CM "$PHPSTAN_MODIFIED_CONFIG" "modified" < /dev/null || STATUS=1
+  # CMR, not CM: a renamed-and-modified PHP file has status R and would otherwise skip the check.
+  check_pushed_commit "$local_oid" CMR "$PHPSTAN_MODIFIED_CONFIG" "modified" < /dev/null || STATUS=1
 done
 
 # Don't bother running the full check, as we check changes files already, and

--- a/.git-hooks-matomo/pre-push
+++ b/.git-hooks-matomo/pre-push
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+
+
+
+### Check we're running in the context of a plugin and get helpful dir variables ###
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+echo "Running pre-commit hook in repo: $REPO_DIR"
+
+if [[ "$REPO_DIR" =~ /plugins/(.*) ]]; then
+    PLUGIN_PATH="plugins/${BASH_REMATCH[1]}/"
+else
+    echo "Not a plugin, not running any further checks"
+    exit 1
+fi
+MATOMO_DIR=$(echo "$REPO_DIR" | sed -E 's|/plugins/.*$||')
+
+
+
+### Figure out how to run PHPStan - ddev or not. ###
+
+COMMAND=""
+# Use local PHP if setup
+if command -v php >/dev/null 2>&1 && [ -f "${MATOMO_DIR}/vendor/bin/phpstan" ]; then
+    COMMAND="${MATOMO_DIR}/vendor/bin/phpstan"
+    PLUGIN_PATH=''
+elif command -v ddev >/dev/null 2>&1; then
+  # Use ddev if setup (overridding local setup)
+  if [ -d "$MATOMO_DIR/.ddev" ]; then
+    cd "$MATOMO_DIR" || exit 1
+    if ddev status 2>&1 > /dev/null; then
+      COMMAND="ddev exec phpstan"
+    fi
+  fi
+fi
+# If no command, exit
+if [[ -z "$COMMAND" ]]; then
+  echo "No way to run phpstan found."
+  exit 1
+fi
+
+
+
+# Basic setup
+cd "$REPO_DIR"
+STATUS=0
+
+
+
+
+### Resolve the base to diff against. ###
+
+# Use the merge base with the remote main branch: the local branch can be stale
+# or missing, which silently widens the diff to files the push doesn't touch.
+MAIN_BRANCH='5.x-dev'
+DIFF_BASE=$(git merge-base HEAD "origin/${MAIN_BRANCH}" 2>/dev/null)
+if [[ -z "$DIFF_BASE" ]]; then
+  echo "Could not resolve the merge base between HEAD and origin/${MAIN_BRANCH}."
+  echo "Run 'git fetch origin ${MAIN_BRANCH}' and push again."
+  exit 1
+fi
+
+
+
+### Run PHPStan on newly created files. ###
+
+PHPSTAN_CREATED_CONFIG=phpstan/phpstan.created.neon
+if [[ -f "$PHPSTAN_CREATED_CONFIG" ]]; then
+  CHANGED_FILES=$(git diff --name-only ${DIFF_BASE} --diff-filter=A | grep '\.php$' || true)
+  if [ -z "$CHANGED_FILES" ]; then
+    echo "No created PHP files"
+  else
+    echo "Running PHPstan at a very high level on new files"
+    CHANGED_FILES=`echo "$CHANGED_FILES" | sed -e 's/^\(.*\)$/"\1"/' | xargs -I{} echo "${PLUGIN_PATH}{}"`
+    echo "$CHANGED_FILES" | xargs $COMMAND analyse -c ${PLUGIN_PATH}${PHPSTAN_CREATED_CONFIG} || STATUS=1
+  fi
+fi
+
+
+
+### Run PHPStan on modified files. ###
+PHPSTAN_MODIFIED_CONFIG=phpstan/phpstan.modified.neon
+if [[ -f "$PHPSTAN_MODIFIED_CONFIG" ]]; then
+  CHANGED_FILES=$(git diff --name-only ${DIFF_BASE} --diff-filter=CM | grep '\.php$' || true)
+  if [ -z "$CHANGED_FILES" ]; then
+    echo "No changed PHP files"
+  else
+    echo "Running PHPstan on modified files"
+    CHANGED_FILES=`echo "$CHANGED_FILES" | sed -e 's/^\(.*\)$/"\1"/' | xargs -I{} echo "${PLUGIN_PATH}{}"`
+    echo "$CHANGED_FILES" | xargs $COMMAND analyse -c ${PLUGIN_PATH}${PHPSTAN_MODIFIED_CONFIG} || STATUS=1
+  fi
+fi
+
+# Don't bother running the full check, as we check changes files already, and
+# can assume that the unchanged files don't need rechecking.
+#
+# Github will check this anyway.
+#
+# PHPSTAN_BASE_CONFIG=phpstan.neon
+# if [[ -f "$PHPSTAN_BASE_CONFIG" ]]; then
+#     echo "Running PHPstan at a base level on all plugin files"
+#   $COMMAND analyse -c ${PLUGIN_PATH}/${PHPSTAN_BASE_CONFIG} || STATUS=1
+# fi
+
+exit $STATUS

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,10 @@
+name: License check
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  license-check:
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-license-check.yml@main

--- a/.github/workflows/matomo-ai-checklist.yml
+++ b/.github/workflows/matomo-ai-checklist.yml
@@ -1,5 +1,3 @@
-# Action for running tests
-
 name: AI Checklist
 
 on:
@@ -8,15 +6,7 @@ on:
 
 permissions:
   actions: read
-  checks: none
-  contents: none
-  deployments: none
-  issues: none
-  packages: none
   pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: none
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,9 +14,4 @@ concurrency:
 
 jobs:
   AiChecklist:
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Run tests
-        uses: matomo-org/github-action-checklist-gate@main
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-ai-checklist.yml@main

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -3,41 +3,10 @@ name: PHPCS check
 on: pull_request
 
 permissions:
-  actions: read
-  checks: read
   contents: read
-  deployments: none
-  issues: read
-  packages: none
-  pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: read
 
 jobs:
   phpcs:
-    name: PHPCS
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: false
-          persist-credentials: false
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-          tools: cs2pr
-      - name: Install dependencies
-        run:
-          composer init --name=matomo/marketingcampaignsreporting --quiet;
-          composer --no-plugins config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true -n;
-          composer config repositories.matomo-coding-standards vcs https://github.com/matomo-org/matomo-coding-standards -n;
-          composer require matomo-org/matomo-coding-standards:dev-master;
-          composer install --dev --prefer-dist --no-progress --no-suggest
-      - name: Check PHP code styles
-        id: phpcs
-        run: ./vendor/bin/phpcs --report-full --standard=phpcs.xml --report-checkstyle=./phpcs-report.xml
-      - name: Show PHPCS results in PR
-        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
-        run: cs2pr ./phpcs-report.xml --prepend-filename
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpcs.yml@main
+    with:
+      plugin-name: MarketingCampaignsReporting

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,83 +3,10 @@ name: PHPStan check
 on: pull_request
 
 permissions:
-  actions: read
-  checks: read
   contents: read
-  deployments: none
-  issues: read
-  packages: none
-  pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: read
-
-env:
-  PLUGIN_NAME: MarketingCampaignsReporting
 
 jobs:
   phpstan:
-    name: PHPStan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: false
-          persist-credentials: false
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.2'
-
-      - name: Check out github-action-tests repository
-        uses: actions/checkout@v4
-        with:
-          repository: matomo-org/github-action-tests
-          ref: main
-          path: github-action-tests
-          persist-credentials: false
-
-      - name: checkout matomo for plugin builds
-        shell: bash
-        run: ${{ github.workspace }}/github-action-tests/scripts/bash/checkout_matomo.sh
-        env:
-          PLUGIN_NAME: ${{ env.PLUGIN_NAME }}
-          WORKSPACE: ${{ github.workspace }}
-          ACTION_PATH: ${{ github.workspace }}/github-action-tests
-          MATOMO_TEST_TARGET: maximum_supported_matomo
-
-      - name: prepare setup
-        shell: bash
-        run: |
-          cd ${{ github.workspace }}/matomo
-          echo -e "composer install"
-          composer install --ignore-platform-reqs
-
-      - name: checkout additional plugins
-        if: ${{ env.DEPENDENT_PLUGINS != '' }}
-        shell: bash
-        working-directory: ${{ github.workspace }}/matomo
-        run: ${{ github.workspace }}/github-action-tests/scripts/bash/checkout_dependent_plugins.sh
-
-        env:
-          DEPENDENT_PLUGINS: ${{ env.DEPENDENT_PLUGINS }}
-          GITHUB_USER_TOKEN: ${{ secrets.TESTS_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
-
-      - name: "Restore result cache"
-        uses: actions/cache/restore@v4
-        with:
-          path: /tmp/phpstan # same as in phpstan.neon
-          key: "phpstan-result-cache-${{ github.run_id }}"
-          restore-keys: |
-            phpstan-result-cache-
-
-      - name: PHPStan whole repo
-        id: phpstan-all
-        run: cd ${{ github.workspace }}/matomo && composer run phpstan -- -vvv -c plugins/${{ env.PLUGIN_NAME }}/phpstan.neon
-
-      - name: "Save result cache"
-        uses: actions/cache/save@v4
-        if: ${{ !cancelled() }}
-        with:
-          path: /tmp/phpstan # same as in phpstan.neon
-          key: "phpstan-result-cache-${{ github.run_id }}"
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpstan.yml@main
+    with:
+      plugin-name: MarketingCampaignsReporting

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,85 @@
+name: PHPStan check
+
+on: pull_request
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: read
+
+env:
+  PLUGIN_NAME: MarketingCampaignsReporting
+
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+          persist-credentials: false
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.2'
+
+      - name: Check out github-action-tests repository
+        uses: actions/checkout@v4
+        with:
+          repository: matomo-org/github-action-tests
+          ref: main
+          path: github-action-tests
+          persist-credentials: false
+
+      - name: checkout matomo for plugin builds
+        shell: bash
+        run: ${{ github.workspace }}/github-action-tests/scripts/bash/checkout_matomo.sh
+        env:
+          PLUGIN_NAME: ${{ env.PLUGIN_NAME }}
+          WORKSPACE: ${{ github.workspace }}
+          ACTION_PATH: ${{ github.workspace }}/github-action-tests
+          MATOMO_TEST_TARGET: maximum_supported_matomo
+
+      - name: prepare setup
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}/matomo
+          echo -e "composer install"
+          composer install --ignore-platform-reqs
+
+      - name: checkout additional plugins
+        if: ${{ env.DEPENDENT_PLUGINS != '' }}
+        shell: bash
+        working-directory: ${{ github.workspace }}/matomo
+        run: ${{ github.workspace }}/github-action-tests/scripts/bash/checkout_dependent_plugins.sh
+
+        env:
+          DEPENDENT_PLUGINS: ${{ env.DEPENDENT_PLUGINS }}
+          GITHUB_USER_TOKEN: ${{ secrets.TESTS_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: "Restore result cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/phpstan # same as in phpstan.neon
+          key: "phpstan-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            phpstan-result-cache-
+
+      - name: PHPStan whole repo
+        id: phpstan-all
+        run: cd ${{ github.workspace }}/matomo && composer run phpstan -- -vvv -c plugins/${{ env.PLUGIN_NAME }}/phpstan.neon
+
+      - name: "Save result cache"
+        uses: actions/cache/save@v4
+        if: ${{ !cancelled() }}
+        with:
+          path: /tmp/phpstan # same as in phpstan.neon
+          key: "phpstan-result-cache-${{ github.run_id }}"

--- a/API.php
+++ b/API.php
@@ -421,6 +421,9 @@ class API extends \Piwik\Plugin\API
     ) {
         if ($dataTable instanceof DataTable) {
             if ($this->isTableEmpty($dataTable)) {
+                // the two tables are built from the same request, so they always have the same
+                // shape: when $dataTable is a DataTable, $referrersDataTable is one too
+                // @phpstan-ignore method.notFound
                 $referrersDataTable->setAllTableMetadata($dataTable->getAllTableMetadata());
                 return $referrersDataTable;
             } else {
@@ -428,6 +431,7 @@ class API extends \Piwik\Plugin\API
             }
         } elseif ($dataTable instanceof DataTable\Map) {
             foreach ($dataTable->getDataTables() as $label => $childTable) {
+                // @phpstan-ignore method.notFound (same-shape invariant: both are Maps here)
                 $newTable = $this->mergeDataTableMaps($childTable, $referrersDataTable->getTable($label));
                 $dataTable->addTable($newTable, $label);
             }

--- a/RecordBuilders/CampaignReporting.php
+++ b/RecordBuilders/CampaignReporting.php
@@ -90,6 +90,7 @@ class CampaignReporting extends RecordBuilder
         }
 
         $whereClause = $table . ".referer_type = " . Common::REFERRER_TYPE_CAMPAIGN;
+        // @phpstan-ignore booleanAnd.rightAlwaysTrue (guard for Matomo < 5.2.0-b6, which the declared range still supports)
         $query = $aggregatorMethod === 'queryConversionsByDimension' && version_compare(Version::VERSION, '5.2.0-b6', '>=')
             ? $logAggregator->$aggregatorMethod($dimensions, $whereClause, [], [], false, false, true)
             : $logAggregator->$aggregatorMethod($dimensions, $whereClause);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 5
     phpVersion: 80100
     tmpDir: /tmp/phpstan/MarketingCampaignsReporting/main
     paths:
@@ -7,6 +7,10 @@ parameters:
     excludePaths:
         - tests/*
         - github-action-tests/ (?)
+    ignoreErrors:
+        # released update files are immutable history and must not be edited for analysis findings
+        - message: '#^Property Piwik\\Plugins\\MarketingCampaignsReporting\\Updates_5_1_0::\$migration is never read, only written\.$#'
+          path: Updates/5.1.0.php
     bootstrapFiles:
         - ../../bootstrap-phpstan.php
     universalObjectCratesClasses:

--- a/phpstan/phpstan.created.neon
+++ b/phpstan/phpstan.created.neon
@@ -1,0 +1,6 @@
+includes:
+    - ../phpstan.neon
+parameters:
+    # new files carry no pre-existing debt, so hold them to the strictest level
+    level: 9
+    tmpDir: /tmp/phpstan/MarketingCampaignsReporting/created

--- a/phpstan/phpstan.modified.neon
+++ b/phpstan/phpstan.modified.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../phpstan.neon
+parameters:
+    level: 5
+    tmpDir: /tmp/phpstan/MarketingCampaignsReporting/modified


### PR DESCRIPTION
## Description
Enforces the PHPStan static analysis this plugin already had configured: a `phpstan.neon` existed at level 1 but no CI check or git hook ran it. This adds the same setup used by other Matomo plugins (e.g. plugin-Slack, plugin-LoginLdap): a GitHub Actions check on every pull request, plus an optional pre-push git hook that analyses changed files (enable it with `git config core.hooksPath .git-hooks-matomo`).

The analysis level is raised from 1 to 5, the highest level the existing code passes (level 6 reports 104 errors). No behaviour changes: the two findings in `API.php` are a same-shape invariant between two DataTables that the analysis cannot see, the `RecordBuilders` finding is a compatibility guard for Matomo < 5.2.0-b6 that the declared support range still needs, and the finding in the released `Updates/5.1.0.php` is ignored via a path-scoped config entry because released update files are immutable history. New files are held to level 9 and modified files to level 5 by the hook, matching the other plugins.

## Issue No
PG-4897

## Steps to Replicate the Issue
1. Run PHPStan for this plugin in a Matomo checkout: `composer run phpstan -- -c plugins/MarketingCampaignsReporting/phpstan.neon`.
2. Expected: the configured analysis level is enforced somewhere.
3. Actual: nothing ran it, and the configured level understated what the code supports.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
