### PR TITLE
Add percent-of-total metric columns to system test expected files

### DIFF
--- a/tests/System/expected/test___MarketingCampaignsReporting.getKeywordContentFromNameId_month.xml
+++ b/tests/System/expected/test___MarketingCampaignsReporting.getKeywordContentFromNameId_month.xml
@@ -10,6 +10,10 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerName==October_Offer;referrerType==campaign;referrerKeyword==Mot_cl%C3%A9_P%C3%89P%C3%88RE</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getContent_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getContent_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>9</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>75%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>75%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>75%</bounce_count_percent_of_total>
 		<segment>campaignContent==none</segment>
 	</row>
 	<row>
@@ -42,6 +46,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<segment>campaignContent==ecommerce_content</segment>
 	</row>
 	<row>
@@ -54,6 +64,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignContent==contains+personalized+campaigns+for+client</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getGroup_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getGroup_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<segment>campaignGroup==ecommmerce_campaigngroup</segment>
 	</row>
 	<row>
@@ -42,6 +48,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==audience+group+1</segment>
 	</row>
 	<row>
@@ -54,6 +64,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==cg1</segment>
 	</row>
 	<row>
@@ -66,6 +80,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==cg2</segment>
 	</row>
 	<row>
@@ -78,6 +96,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==cg3</segment>
 	</row>
 	<row>
@@ -90,6 +112,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==cg4</segment>
 	</row>
 	<row>
@@ -102,6 +128,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==cg5</segment>
 	</row>
 	<row>
@@ -114,6 +144,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==cg6</segment>
 	</row>
 	<row>
@@ -126,6 +160,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==cg7</segment>
 	</row>
 	<row>
@@ -138,6 +176,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==cg8</segment>
 	</row>
 	<row>
@@ -150,6 +192,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignGroup==group+1</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getId_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getId_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
 		<segment>campaignId==campaign_id_kaboom</segment>
 	</row>
 	<row>
@@ -42,6 +46,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<segment>campaignId==ecommmerce_campaignid</segment>
 	</row>
 	<row>
@@ -54,6 +64,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignId==cid1</segment>
 	</row>
 	<row>
@@ -66,6 +80,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignId==cid2</segment>
 	</row>
 	<row>
@@ -78,6 +96,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignId==cid3</segment>
 	</row>
 	<row>
@@ -90,6 +112,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignId==cid4</segment>
 	</row>
 	<row>
@@ -102,6 +128,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignId==cid5</segment>
 	</row>
 	<row>
@@ -114,6 +144,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignId==cid6</segment>
 	</row>
 	<row>
@@ -126,6 +160,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignId==cid7</segment>
 	</row>
 	<row>
@@ -138,6 +176,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignId==cid8</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getKeyword_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getKeyword_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>13.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>13.3%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<segment>campaignKeyword==ecommerce_keyword</segment>
 	</row>
 	<row>
@@ -42,6 +48,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>13.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>13.3%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==mot_cl%C3%A9_p%C3%A9p%C3%A8re</segment>
 	</row>
 	<row>
@@ -54,6 +64,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+a</segment>
 	</row>
 	<row>
@@ -66,6 +80,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+b</segment>
 	</row>
 	<row>
@@ -78,6 +96,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+c</segment>
 	</row>
 	<row>
@@ -90,6 +112,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+d</segment>
 	</row>
 	<row>
@@ -102,6 +128,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+e</segment>
 	</row>
 	<row>
@@ -114,6 +144,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+f</segment>
 	</row>
 	<row>
@@ -126,6 +160,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+from+%23hash+tag+parameter</segment>
 	</row>
 	<row>
@@ -138,6 +176,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+g</segment>
 	</row>
 	<row>
@@ -150,6 +192,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==keyword+h</segment>
 	</row>
 	<row>
@@ -162,6 +208,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22k</segment>
 	</row>
 	<row>
@@ -174,6 +224,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<segment>campaignKeyword==not_an_advanced_campaign_at_first</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getMedium_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getMedium_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>10</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>83.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>83.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>83.3%</bounce_count_percent_of_total>
 		<segment>campaignMedium==email</segment>
 	</row>
 	<row>
@@ -42,6 +46,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<segment>campaignMedium==ecommerce_medium</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getName_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getName_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 		<segment>campaignName==ecommerce_campaign</segment>
 		<subtable>
 			<row>
@@ -62,6 +68,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -75,6 +87,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==10th</segment>
 		<subtable>
 			<row>
@@ -87,6 +103,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -100,6 +120,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==11th</segment>
 		<subtable>
 			<row>
@@ -112,6 +136,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -125,6 +153,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==12th</segment>
 		<subtable>
 			<row>
@@ -137,6 +169,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -150,6 +186,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==13th</segment>
 		<subtable>
 			<row>
@@ -162,6 +202,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -175,6 +219,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==14th</segment>
 		<subtable>
 			<row>
@@ -187,6 +235,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -200,6 +252,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==15th</segment>
 		<subtable>
 			<row>
@@ -212,6 +268,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -225,6 +285,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==16th</segment>
 		<subtable>
 			<row>
@@ -237,6 +301,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -250,6 +318,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==17th</segment>
 		<subtable>
 			<row>
@@ -262,6 +334,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -275,6 +351,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==campaignnamedimension+-+no+other+dimension+for+this+visit</segment>
 	</row>
 	<row>
@@ -287,6 +367,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==campaign_hashed</segment>
 		<subtable>
 			<row>
@@ -299,6 +383,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -326,6 +414,12 @@
 		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>4444</revenue>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 		<segment>campaignName==campaign_with_two_goals_conversions</segment>
 	</row>
 	<row>
@@ -338,6 +432,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==default_offer</segment>
 		<subtable>
 			<row>
@@ -350,6 +448,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -363,6 +465,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22nam</segment>
 		<subtable>
 			<row>
@@ -375,6 +481,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -388,6 +498,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==november_offer</segment>
 		<subtable>
 			<row>
@@ -400,6 +514,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -413,6 +531,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==october_offer</segment>
 		<subtable>
 			<row>
@@ -425,6 +547,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -438,6 +564,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>campaignName==should_be_new_visit</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getPlacement_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getPlacement_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<segment>campaignPlacement==ecommmerce_campaignplacement</segment>
 	</row>
 	<row>
@@ -42,6 +48,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==bottom</segment>
 	</row>
 	<row>
@@ -54,6 +64,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==bottom-left</segment>
 	</row>
 	<row>
@@ -66,6 +80,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==center</segment>
 	</row>
 	<row>
@@ -78,6 +96,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==google+ads</segment>
 	</row>
 	<row>
@@ -90,6 +112,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==google+search</segment>
 	</row>
 	<row>
@@ -102,6 +128,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==left</segment>
 	</row>
 	<row>
@@ -114,6 +144,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==middle</segment>
 	</row>
 	<row>
@@ -126,6 +160,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==right</segment>
 	</row>
 	<row>
@@ -138,6 +176,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==top</segment>
 	</row>
 	<row>
@@ -150,6 +192,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<segment>campaignPlacement==top-right</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getSourceMedium_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getSourceMedium_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<subtable>
 			<row>
 				<label>ecommerce_campaign</label>
@@ -61,6 +67,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -74,6 +86,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;nam</label>
@@ -85,6 +101,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -98,6 +118,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>october_offer</label>
@@ -109,6 +133,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -122,6 +150,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>november_offer</label>
@@ -133,6 +165,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -146,6 +182,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>10th</label>
@@ -157,6 +197,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -170,6 +214,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>11th</label>
@@ -181,6 +229,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -194,6 +246,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>12th</label>
@@ -205,6 +261,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -218,6 +278,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>13th</label>
@@ -229,6 +293,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -242,6 +310,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>14th</label>
@@ -253,6 +325,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -266,6 +342,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>15th</label>
@@ -277,6 +357,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -290,6 +374,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>16th</label>
@@ -301,6 +389,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -314,6 +406,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<subtable>
 			<row>
 				<label>17th</label>
@@ -325,6 +421,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/tests/System/expected/test_expanded__MarketingCampaignsReporting.getSource_day.xml
+++ b/tests/System/expected/test_expanded__MarketingCampaignsReporting.getSource_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<segment>campaignSource==ecommerce_source</segment>
 	</row>
 	<row>
@@ -42,6 +48,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==lenghty+%22source%22...lenghty+%22source%22...lenghty+%22source%22...</segment>
 	</row>
 	<row>
@@ -54,6 +64,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_6</segment>
 	</row>
 	<row>
@@ -66,6 +80,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_7</segment>
 	</row>
 	<row>
@@ -78,6 +96,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_10</segment>
 	</row>
 	<row>
@@ -90,6 +112,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_11</segment>
 	</row>
 	<row>
@@ -102,6 +128,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_12</segment>
 	</row>
 	<row>
@@ -114,6 +144,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_13</segment>
 	</row>
 	<row>
@@ -126,6 +160,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_14</segment>
 	</row>
 	<row>
@@ -138,6 +176,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_15</segment>
 	</row>
 	<row>
@@ -150,6 +192,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_16</segment>
 	</row>
 	<row>
@@ -162,6 +208,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<segment>campaignSource==newsletter_17</segment>
 	</row>
 </result>

--- a/tests/System/expected/test_expanded__Referrers.getCampaigns_day.xml
+++ b/tests/System/expected/test_expanded__Referrers.getCampaigns_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>1444</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
+		<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Ecommerce_campaign</segment>
 		<subtable>
 			<row>
@@ -22,6 +26,10 @@
 				<sum_visit_length>1444</sum_visit_length>
 				<bounce_count>2</bounce_count>
 				<nb_visits_converted>1</nb_visits_converted>
+				<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -35,6 +43,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==10th</segment>
 		<subtable>
 			<row>
@@ -47,6 +59,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -60,6 +76,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==11th</segment>
 		<subtable>
 			<row>
@@ -72,6 +92,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -85,6 +109,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==12th</segment>
 		<subtable>
 			<row>
@@ -97,6 +125,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -110,6 +142,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==13th</segment>
 		<subtable>
 			<row>
@@ -122,6 +158,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -135,6 +175,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==14th</segment>
 		<subtable>
 			<row>
@@ -147,6 +191,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -160,6 +208,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==15th</segment>
 		<subtable>
 			<row>
@@ -172,6 +224,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -185,6 +241,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==16th</segment>
 		<subtable>
 			<row>
@@ -197,6 +257,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -210,6 +274,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==17th</segment>
 		<subtable>
 			<row>
@@ -222,6 +290,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -235,6 +307,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==CampaignNameDimension+-+No+Other+Dimension+for+this+visit</segment>
 	</row>
 	<row>
@@ -247,6 +323,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Campaign_Hashed</segment>
 		<subtable>
 			<row>
@@ -259,6 +339,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -272,6 +356,10 @@
 		<sum_visit_length>725</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Campaign_with_two_goals_conversions</segment>
 	</row>
 	<row>
@@ -284,6 +372,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Default_Offer</segment>
 		<subtable>
 			<row>
@@ -296,6 +388,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -309,6 +405,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAM</segment>
 		<subtable>
 			<row>
@@ -321,6 +421,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -334,6 +438,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==November_Offer</segment>
 		<subtable>
 			<row>
@@ -346,6 +454,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -359,6 +471,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==October_Offer</segment>
 		<subtable>
 			<row>
@@ -371,6 +487,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -384,6 +504,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==SHOULD_BE_NEW_VISIT</segment>
 	</row>
 	<row>
@@ -403,6 +527,9 @@
 		<nb_conversions>3</nb_conversions>
 		<revenue>4444</revenue>
 		<nb_visits>0</nb_visits>
+		<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+		<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+		<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 		<segment>referrerType==campaign;referrerName==campaign_with_two_goals_conversions</segment>
 	</row>
 	<row>
@@ -428,6 +555,9 @@
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
 		<nb_visits>0</nb_visits>
+		<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+		<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+		<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 		<segment>referrerType==campaign;referrerName==ecommerce_campaign</segment>
 		<subtable>
 			<row>
@@ -453,6 +583,9 @@
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
 				<nb_visits>0</nb_visits>
+				<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+				<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+				<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getContent_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getContent_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>9</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>75%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>75%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>75%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignContent>none</MarketingCampaignsReporting_CampaignContent>
 		<segment>campaignContent==none</segment>
 	</row>
@@ -43,6 +47,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignContent>ecommerce_content</MarketingCampaignsReporting_CampaignContent>
 		<segment>campaignContent==ecommerce_content</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignContent>contains personalized campaigns for client</MarketingCampaignsReporting_CampaignContent>
 		<segment>campaignContent==contains+personalized+campaigns+for+client</segment>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getGroup_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getGroup_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>ecommmerce_campaigngroup</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==ecommmerce_campaigngroup</segment>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>audience group 1</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==audience+group+1</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg1</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg1</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg2</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg2</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg3</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg3</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg4</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg4</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg5</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg5</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg6</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg6</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg7</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg7</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg8</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg8</segment>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>group 1</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==group+1</segment>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getId_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getId_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>campaign_id_kaboom</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==campaign_id_kaboom</segment>
 	</row>
@@ -43,6 +47,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>ecommmerce_campaignid</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==ecommmerce_campaignid</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid1</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid1</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid2</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid2</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid3</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid3</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid4</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid4</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid5</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid5</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid6</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid6</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid7</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid7</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid8</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid8</segment>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getKeyword_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getKeyword_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>13.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>13.3%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>ecommerce_keyword</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==ecommerce_keyword</segment>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>13.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>13.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>mot_clé_pépère</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==mot_cl%C3%A9_p%C3%A9p%C3%A8re</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword a</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+a</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword b</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+b</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword c</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+c</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword d</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+d</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword e</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+e</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword f</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+f</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword from #hash tag parameter</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+from+%23hash+tag+parameter</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword g</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+g</segment>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword h</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+h</segment>
 	</row>
@@ -173,6 +219,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;k</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22k</segment>
 	</row>
@@ -186,6 +236,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>not_an_advanced_campaign_at_first</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==not_an_advanced_campaign_at_first</segment>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getMedium_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getMedium_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>10</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>83.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>83.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>83.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignMedium>email</MarketingCampaignsReporting_CampaignMedium>
 		<segment>campaignMedium==email</segment>
 	</row>
@@ -43,6 +47,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignMedium>ecommerce_medium</MarketingCampaignsReporting_CampaignMedium>
 		<segment>campaignMedium==ecommerce_medium</segment>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getName_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getName_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>ecommerce_campaign</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>ecommerce_keyword - ecommerce_content</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==ecommerce_campaign</segment>
@@ -44,6 +50,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>10th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword a - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==10th</segment>
@@ -58,6 +68,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>11th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword b - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==11th</segment>
@@ -72,6 +86,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>12th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword c - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==12th</segment>
@@ -86,6 +104,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>13th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword d - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==13th</segment>
@@ -100,6 +122,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>14th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword e - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==14th</segment>
@@ -114,6 +140,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>15th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword f - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==15th</segment>
@@ -128,6 +158,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>16th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword g - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==16th</segment>
@@ -142,6 +176,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>17th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword h - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==17th</segment>
@@ -156,6 +194,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>campaignnamedimension - no other dimension for this visit</MarketingCampaignsReporting_CampaignName>
 		<segment>campaignName==campaignnamedimension+-+no+other+dimension+for+this+visit</segment>
 	</row>
@@ -169,6 +211,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>campaign_hashed</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword from #hash tag parameter</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==campaign_hashed</segment>
@@ -197,6 +243,12 @@
 		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>4444</revenue>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>campaign_with_two_goals_conversions</MarketingCampaignsReporting_CampaignName>
 		<segment>campaignName==campaign_with_two_goals_conversions</segment>
 	</row>
@@ -210,6 +262,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>default_offer</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>not_an_advanced_campaign_at_first</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==default_offer</segment>
@@ -224,6 +280,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;nam</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;k</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22nam</segment>
@@ -238,6 +298,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>november_offer</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>mot_clé_pépère - contains personalized campaigns for client</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==november_offer</segment>
@@ -252,6 +316,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>october_offer</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>mot_clé_pépère - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==october_offer</segment>
@@ -266,6 +334,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>should_be_new_visit</MarketingCampaignsReporting_CampaignName>
 		<segment>campaignName==should_be_new_visit</segment>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getPlacement_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getPlacement_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>ecommmerce_campaignplacement</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==ecommmerce_campaignplacement</segment>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>bottom</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==bottom</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>bottom-left</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==bottom-left</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>center</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==center</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>google ads</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==google+ads</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>google search</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==google+search</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>left</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==left</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>middle</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==middle</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>right</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==right</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>top</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==top</segment>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>top-right</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==top-right</segment>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getSourceMedium_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getSourceMedium_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>ecommerce_source - ecommerce_medium</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>ecommerce_campaign</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>lenghty &quot;source&quot;...lenghty &quot;source&quot;...lenghty &quot;source&quot;...</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;nam</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_6 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>october_offer</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_7 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>november_offer</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_10 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>10th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_11 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>11th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_12 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>12th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_13 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>13th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_14 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>14th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_15 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>15th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_16 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>16th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -173,6 +219,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_17 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>17th</MarketingCampaignsReporting_CampaignName>
 	</row>

--- a/tests/System/expected/test_flat__MarketingCampaignsReporting.getSource_day.xml
+++ b/tests/System/expected/test_flat__MarketingCampaignsReporting.getSource_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>ecommerce_source</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==ecommerce_source</segment>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>lenghty &quot;source&quot;...lenghty &quot;source&quot;...lenghty &quot;source&quot;...</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==lenghty+%22source%22...lenghty+%22source%22...lenghty+%22source%22...</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_6</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_6</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_7</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_7</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_10</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_10</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_11</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_11</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_12</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_12</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_13</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_13</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_14</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_14</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_15</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_15</segment>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_16</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_16</segment>
 	</row>
@@ -173,6 +219,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_17</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_17</segment>
 	</row>

--- a/tests/System/expected/test_flat__Referrers.getCampaigns_day.xml
+++ b/tests/System/expected/test_flat__Referrers.getCampaigns_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>1444</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
+		<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Ecommerce_campaign;referrerType==campaign;referrerKeyword==Ecommerce_keyword</segment>
 		<Referrers_Campaign>Ecommerce_campaign</Referrers_Campaign>
 		<Referrers_Keyword>Ecommerce_keyword</Referrers_Keyword>
@@ -24,6 +28,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==10th;referrerType==campaign;referrerKeyword==keyword+a</segment>
 		<Referrers_Campaign>10th</Referrers_Campaign>
 		<Referrers_Keyword>keyword a</Referrers_Keyword>
@@ -38,6 +46,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==11th;referrerType==campaign;referrerKeyword==keyword+b</segment>
 		<Referrers_Campaign>11th</Referrers_Campaign>
 		<Referrers_Keyword>keyword b</Referrers_Keyword>
@@ -52,6 +64,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==12th;referrerType==campaign;referrerKeyword==keyword+c</segment>
 		<Referrers_Campaign>12th</Referrers_Campaign>
 		<Referrers_Keyword>keyword c</Referrers_Keyword>
@@ -66,6 +82,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==13th;referrerType==campaign;referrerKeyword==keyword+d</segment>
 		<Referrers_Campaign>13th</Referrers_Campaign>
 		<Referrers_Keyword>keyword d</Referrers_Keyword>
@@ -80,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==14th;referrerType==campaign;referrerKeyword==keyword+e</segment>
 		<Referrers_Campaign>14th</Referrers_Campaign>
 		<Referrers_Keyword>keyword e</Referrers_Keyword>
@@ -94,6 +118,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==15th;referrerType==campaign;referrerKeyword==keyword+f</segment>
 		<Referrers_Campaign>15th</Referrers_Campaign>
 		<Referrers_Keyword>keyword f</Referrers_Keyword>
@@ -108,6 +136,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==16th;referrerType==campaign;referrerKeyword==keyword+g</segment>
 		<Referrers_Campaign>16th</Referrers_Campaign>
 		<Referrers_Keyword>keyword g</Referrers_Keyword>
@@ -122,6 +154,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==17th;referrerType==campaign;referrerKeyword==keyword+h</segment>
 		<Referrers_Campaign>17th</Referrers_Campaign>
 		<Referrers_Keyword>keyword h</Referrers_Keyword>
@@ -136,6 +172,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==CampaignNameDimension+-+No+Other+Dimension+for+this+visit</segment>
 		<Referrers_Campaign>CampaignNameDimension - No Other Dimension for this visit</Referrers_Campaign>
 	</row>
@@ -149,6 +189,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Campaign_Hashed;referrerType==campaign;referrerKeyword==Keyword+from+%23hash+tag+parameter</segment>
 		<Referrers_Campaign>Campaign_Hashed</Referrers_Campaign>
 		<Referrers_Keyword>Keyword from #hash tag parameter</Referrers_Keyword>
@@ -163,6 +207,10 @@
 		<sum_visit_length>725</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Campaign_with_two_goals_conversions</segment>
 		<Referrers_Campaign>Campaign_with_two_goals_conversions</Referrers_Campaign>
 	</row>
@@ -176,6 +224,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Default_Offer;referrerType==campaign;referrerKeyword==Not_An_Advanced_Campaign_At_first</segment>
 		<Referrers_Campaign>Default_Offer</Referrers_Campaign>
 		<Referrers_Keyword>Not_An_Advanced_Campaign_At_first</Referrers_Keyword>
@@ -190,6 +242,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAM;referrerType==campaign;referrerKeyword==Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22K</segment>
 		<Referrers_Campaign>Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAM</Referrers_Campaign>
 		<Referrers_Keyword>Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;K</Referrers_Keyword>
@@ -204,6 +260,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==November_Offer;referrerType==campaign;referrerKeyword==Mot_cl%C3%A9_P%C3%89P%C3%88RE</segment>
 		<Referrers_Campaign>November_Offer</Referrers_Campaign>
 		<Referrers_Keyword>Mot_clé_PÉPÈRE</Referrers_Keyword>
@@ -218,6 +278,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==October_Offer;referrerType==campaign;referrerKeyword==Mot_cl%C3%A9_P%C3%89P%C3%88RE</segment>
 		<Referrers_Campaign>October_Offer</Referrers_Campaign>
 		<Referrers_Keyword>Mot_clé_PÉPÈRE</Referrers_Keyword>
@@ -232,6 +296,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==SHOULD_BE_NEW_VISIT</segment>
 		<Referrers_Campaign>SHOULD_BE_NEW_VISIT</Referrers_Campaign>
 	</row>
@@ -252,6 +320,9 @@
 		<nb_conversions>3</nb_conversions>
 		<revenue>4444</revenue>
 		<nb_visits>0</nb_visits>
+		<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+		<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+		<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 		<segment>referrerType==campaign;referrerName==campaign_with_two_goals_conversions</segment>
 		<Referrers_Campaign>campaign_with_two_goals_conversions</Referrers_Campaign>
 	</row>
@@ -278,6 +349,9 @@
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
 		<nb_visits>0</nb_visits>
+		<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+		<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+		<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 		<segment>referrerType==campaign;referrerName==ecommerce_campaign;referrerType==campaign;referrerKeyword==ecommerce_keyword</segment>
 		<Referrers_Campaign>ecommerce_campaign</Referrers_Campaign>
 		<Referrers_Keyword>ecommerce_keyword</Referrers_Keyword>

--- a/tests/System/expected/test_min_php_expanded__Referrers.getCampaigns_day.xml
+++ b/tests/System/expected/test_min_php_expanded__Referrers.getCampaigns_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>1444</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
+		<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Ecommerce_campaign</segment>
 		<subtable>
 			<row>
@@ -22,6 +26,10 @@
 				<sum_visit_length>1444</sum_visit_length>
 				<bounce_count>2</bounce_count>
 				<nb_visits_converted>1</nb_visits_converted>
+				<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -35,6 +43,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==10th</segment>
 		<subtable>
 			<row>
@@ -47,6 +59,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -60,6 +76,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==11th</segment>
 		<subtable>
 			<row>
@@ -72,6 +92,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -85,6 +109,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==12th</segment>
 		<subtable>
 			<row>
@@ -97,6 +125,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -110,6 +142,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==13th</segment>
 		<subtable>
 			<row>
@@ -122,6 +158,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -135,6 +175,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==14th</segment>
 		<subtable>
 			<row>
@@ -147,6 +191,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -160,6 +208,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==15th</segment>
 		<subtable>
 			<row>
@@ -172,6 +224,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -185,6 +241,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==16th</segment>
 		<subtable>
 			<row>
@@ -197,6 +257,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -210,6 +274,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==17th</segment>
 		<subtable>
 			<row>
@@ -222,6 +290,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -235,6 +307,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==CampaignNameDimension+-+No+Other+Dimension+for+this+visit</segment>
 	</row>
 	<row>
@@ -247,6 +323,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Campaign_Hashed</segment>
 		<subtable>
 			<row>
@@ -259,6 +339,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -272,6 +356,10 @@
 		<sum_visit_length>725</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Campaign_with_two_goals_conversions</segment>
 	</row>
 	<row>
@@ -284,6 +372,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Default_Offer</segment>
 		<subtable>
 			<row>
@@ -296,6 +388,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -309,6 +405,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAME%22...Lenghty+%22NAM</segment>
 		<subtable>
 			<row>
@@ -321,6 +421,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -334,6 +438,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==November_Offer</segment>
 		<subtable>
 			<row>
@@ -346,6 +454,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -359,6 +471,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==October_Offer</segment>
 		<subtable>
 			<row>
@@ -371,6 +487,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -384,6 +504,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==SHOULD_BE_NEW_VISIT</segment>
 	</row>
 	<row>
@@ -403,6 +527,9 @@
 		<nb_conversions>3</nb_conversions>
 		<revenue>4444</revenue>
 		<nb_visits>0</nb_visits>
+		<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+		<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+		<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 		<segment>referrerType==campaign;referrerName==campaign_with_two_goals_conversions</segment>
 	</row>
 	<row>
@@ -428,6 +555,9 @@
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
 		<nb_visits>0</nb_visits>
+		<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+		<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+		<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 		<segment>referrerType==campaign;referrerName==ecommerce_campaign</segment>
 		<subtable>
 			<row>
@@ -453,6 +583,9 @@
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
 				<nb_visits>0</nb_visits>
+				<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+				<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+				<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/tests/System/expected/test_min_php_flat__Referrers.getCampaigns_day.xml
+++ b/tests/System/expected/test_min_php_flat__Referrers.getCampaigns_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>1444</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
+		<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Ecommerce_campaign;referrerType==campaign;referrerKeyword==Ecommerce_keyword</segment>
 		<Referrers_Campaign>Ecommerce_campaign</Referrers_Campaign>
 		<Referrers_Keyword>Ecommerce_keyword</Referrers_Keyword>
@@ -24,6 +28,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==10th;referrerType==campaign;referrerKeyword==keyword+a</segment>
 		<Referrers_Campaign>10th</Referrers_Campaign>
 		<Referrers_Keyword>keyword a</Referrers_Keyword>
@@ -38,6 +46,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==11th;referrerType==campaign;referrerKeyword==keyword+b</segment>
 		<Referrers_Campaign>11th</Referrers_Campaign>
 		<Referrers_Keyword>keyword b</Referrers_Keyword>
@@ -52,6 +64,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==12th;referrerType==campaign;referrerKeyword==keyword+c</segment>
 		<Referrers_Campaign>12th</Referrers_Campaign>
 		<Referrers_Keyword>keyword c</Referrers_Keyword>
@@ -66,6 +82,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==13th;referrerType==campaign;referrerKeyword==keyword+d</segment>
 		<Referrers_Campaign>13th</Referrers_Campaign>
 		<Referrers_Keyword>keyword d</Referrers_Keyword>
@@ -80,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==14th;referrerType==campaign;referrerKeyword==keyword+e</segment>
 		<Referrers_Campaign>14th</Referrers_Campaign>
 		<Referrers_Keyword>keyword e</Referrers_Keyword>
@@ -94,6 +118,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==15th;referrerType==campaign;referrerKeyword==keyword+f</segment>
 		<Referrers_Campaign>15th</Referrers_Campaign>
 		<Referrers_Keyword>keyword f</Referrers_Keyword>
@@ -108,6 +136,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==16th;referrerType==campaign;referrerKeyword==keyword+g</segment>
 		<Referrers_Campaign>16th</Referrers_Campaign>
 		<Referrers_Keyword>keyword g</Referrers_Keyword>
@@ -122,6 +154,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==17th;referrerType==campaign;referrerKeyword==keyword+h</segment>
 		<Referrers_Campaign>17th</Referrers_Campaign>
 		<Referrers_Keyword>keyword h</Referrers_Keyword>
@@ -136,6 +172,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==CampaignNameDimension+-+No+Other+Dimension+for+this+visit</segment>
 		<Referrers_Campaign>CampaignNameDimension - No Other Dimension for this visit</Referrers_Campaign>
 	</row>
@@ -149,6 +189,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Campaign_Hashed;referrerType==campaign;referrerKeyword==Keyword+from+%23hash+tag+parameter</segment>
 		<Referrers_Campaign>Campaign_Hashed</Referrers_Campaign>
 		<Referrers_Keyword>Keyword from #hash tag parameter</Referrers_Keyword>
@@ -163,6 +207,10 @@
 		<sum_visit_length>725</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Campaign_with_two_goals_conversions</segment>
 		<Referrers_Campaign>Campaign_with_two_goals_conversions</Referrers_Campaign>
 	</row>
@@ -176,6 +224,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Default_Offer;referrerType==campaign;referrerKeyword==Not_An_Advanced_Campaign_At_first</segment>
 		<Referrers_Campaign>Default_Offer</Referrers_Campaign>
 		<Referrers_Keyword>Not_An_Advanced_Campaign_At_first</Referrers_Keyword>
@@ -190,6 +242,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAM;referrerType==campaign;referrerKeyword==Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22KEYWORD%22...Lenghty+%22K</segment>
 		<Referrers_Campaign>Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAME&quot;...Lenghty &quot;NAM</Referrers_Campaign>
 		<Referrers_Keyword>Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;KEYWORD&quot;...Lenghty &quot;K</Referrers_Keyword>
@@ -204,6 +260,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==November_Offer;referrerType==campaign;referrerKeyword==Mot_cl%C3%A9_P%C3%89P%C3%88RE</segment>
 		<Referrers_Campaign>November_Offer</Referrers_Campaign>
 		<Referrers_Keyword>Mot_clé_PÉPÈRE</Referrers_Keyword>
@@ -218,6 +278,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==October_Offer;referrerType==campaign;referrerKeyword==Mot_cl%C3%A9_P%C3%89P%C3%88RE</segment>
 		<Referrers_Campaign>October_Offer</Referrers_Campaign>
 		<Referrers_Keyword>Mot_clé_PÉPÈRE</Referrers_Keyword>
@@ -232,6 +296,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<segment>referrerType==campaign;referrerName==SHOULD_BE_NEW_VISIT</segment>
 		<Referrers_Campaign>SHOULD_BE_NEW_VISIT</Referrers_Campaign>
 	</row>
@@ -252,6 +320,9 @@
 		<nb_conversions>3</nb_conversions>
 		<revenue>4444</revenue>
 		<nb_visits>0</nb_visits>
+		<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+		<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+		<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 		<segment>referrerType==campaign;referrerName==campaign_with_two_goals_conversions</segment>
 		<Referrers_Campaign>campaign_with_two_goals_conversions</Referrers_Campaign>
 	</row>
@@ -278,6 +349,9 @@
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
 		<nb_visits>0</nb_visits>
+		<nb_visits_percent_of_total>0%</nb_visits_percent_of_total>
+		<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+		<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 		<segment>referrerType==campaign;referrerName==ecommerce_campaign;referrerType==campaign;referrerKeyword==ecommerce_keyword</segment>
 		<Referrers_Campaign>ecommerce_campaign</Referrers_Campaign>
 		<Referrers_Keyword>ecommerce_keyword</Referrers_Keyword>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getContent_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getContent_day.xml
@@ -13,6 +13,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>9</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>75%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>75%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>75%</bounce_count_percent_of_total>
 				<segment>campaignContent==none</segment>
 			</row>
 			<row>
@@ -45,6 +49,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 				<segment>campaignContent==ecommerce_content</segment>
 			</row>
 			<row>
@@ -57,6 +67,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignContent==contains+personalized+campaigns+for+client</segment>
 			</row>
 		</result>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getGroup_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getGroup_day.xml
@@ -33,6 +33,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 				<segment>campaignGroup==ecommmerce_campaigngroup</segment>
 			</row>
 			<row>
@@ -45,6 +51,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==audience+group+1</segment>
 			</row>
 			<row>
@@ -57,6 +67,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==cg1</segment>
 			</row>
 			<row>
@@ -69,6 +83,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==cg2</segment>
 			</row>
 			<row>
@@ -81,6 +99,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==cg3</segment>
 			</row>
 			<row>
@@ -93,6 +115,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==cg4</segment>
 			</row>
 			<row>
@@ -105,6 +131,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==cg5</segment>
 			</row>
 			<row>
@@ -117,6 +147,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==cg6</segment>
 			</row>
 			<row>
@@ -129,6 +163,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==cg7</segment>
 			</row>
 			<row>
@@ -141,6 +179,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==cg8</segment>
 			</row>
 			<row>
@@ -153,6 +195,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignGroup==group+1</segment>
 			</row>
 		</result>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getId_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getId_day.xml
@@ -13,6 +13,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>2</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
 				<segment>campaignId==campaign_id_kaboom</segment>
 			</row>
 			<row>
@@ -45,6 +49,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 				<segment>campaignId==ecommmerce_campaignid</segment>
 			</row>
 			<row>
@@ -57,6 +67,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignId==cid1</segment>
 			</row>
 			<row>
@@ -69,6 +83,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignId==cid2</segment>
 			</row>
 			<row>
@@ -81,6 +99,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignId==cid3</segment>
 			</row>
 			<row>
@@ -93,6 +115,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignId==cid4</segment>
 			</row>
 			<row>
@@ -105,6 +131,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignId==cid5</segment>
 			</row>
 			<row>
@@ -117,6 +147,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignId==cid6</segment>
 			</row>
 			<row>
@@ -129,6 +163,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignId==cid7</segment>
 			</row>
 			<row>
@@ -141,6 +179,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignId==cid8</segment>
 			</row>
 		</result>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getKeyword_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getKeyword_day.xml
@@ -32,6 +32,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>12.5%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>14.3%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 			</row>
 			<row>
 				<label>keyword a</label>
@@ -43,6 +49,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>keyword b</label>
@@ -54,6 +64,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>keyword c</label>
@@ -65,6 +79,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>keyword d</label>
@@ -76,6 +94,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>keyword e</label>
@@ -87,6 +109,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>keyword f</label>
@@ -98,6 +124,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>keyword from #hash tag parameter</label>
@@ -109,6 +139,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>keyword g</label>
@@ -120,6 +154,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>keyword h</label>
@@ -131,6 +169,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keywor</label>
@@ -142,6 +184,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>mot_clé_pépère</label>
@@ -153,6 +199,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>mot_clé_pépère</label>
@@ -164,6 +214,10 @@
 				<sum_visit_length>721</sum_visit_length>
 				<bounce_count>0</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>12.5%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 			</row>
 			<row>
 				<label>not_an_advanced_campaign_at_first</label>
@@ -175,6 +229,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.1%</bounce_count_percent_of_total>
 			</row>
 		</result>
 		<result date="2013-01-23">
@@ -208,6 +266,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>13.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>13.3%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 				<segment>campaignKeyword==ecommerce_keyword</segment>
 			</row>
 			<row>
@@ -220,6 +284,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>2</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>13.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>13.3%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==mot_cl%C3%A9_p%C3%A9p%C3%A8re</segment>
 			</row>
 			<row>
@@ -232,6 +300,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+a</segment>
 			</row>
 			<row>
@@ -244,6 +316,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+b</segment>
 			</row>
 			<row>
@@ -256,6 +332,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+c</segment>
 			</row>
 			<row>
@@ -268,6 +348,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+d</segment>
 			</row>
 			<row>
@@ -280,6 +364,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+e</segment>
 			</row>
 			<row>
@@ -292,6 +380,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+f</segment>
 			</row>
 			<row>
@@ -304,6 +396,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+from+%23hash+tag+parameter</segment>
 			</row>
 			<row>
@@ -316,6 +412,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+g</segment>
 			</row>
 			<row>
@@ -328,6 +428,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==keyword+h</segment>
 			</row>
 			<row>
@@ -340,6 +444,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22k</segment>
 			</row>
 			<row>
@@ -352,6 +460,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 				<segment>campaignKeyword==not_an_advanced_campaign_at_first</segment>
 			</row>
 		</result>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getMedium_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getMedium_day.xml
@@ -13,6 +13,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>10</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>83.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>83.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>83.3%</bounce_count_percent_of_total>
 				<segment>campaignMedium==email</segment>
 			</row>
 			<row>
@@ -45,6 +49,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 				<segment>campaignMedium==ecommerce_medium</segment>
 			</row>
 		</result>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getName_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getName_day.xml
@@ -32,6 +32,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>11.8%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>12.5%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 				<segment>referrerType==campaign;referrerName==ecommerce_campaign</segment>
 				<subtable>
 					<row>
@@ -64,6 +70,12 @@
 						</goals>
 						<nb_conversions>1</nb_conversions>
 						<revenue>555</revenue>
+						<nb_visits_percent_of_total>11.8%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+						<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+						<bounce_count_percent_of_total>12.5%</bounce_count_percent_of_total>
+						<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -77,6 +89,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==10th</segment>
 				<subtable>
 					<row>
@@ -89,6 +105,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -102,6 +122,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==11th</segment>
 				<subtable>
 					<row>
@@ -114,6 +138,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -127,6 +155,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==12th</segment>
 				<subtable>
 					<row>
@@ -139,6 +171,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -152,6 +188,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==13th</segment>
 				<subtable>
 					<row>
@@ -164,6 +204,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -177,6 +221,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==14th</segment>
 				<subtable>
 					<row>
@@ -189,6 +237,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -202,6 +254,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==15th</segment>
 				<subtable>
 					<row>
@@ -214,6 +270,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -227,6 +287,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==16th</segment>
 				<subtable>
 					<row>
@@ -239,6 +303,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -252,6 +320,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==17th</segment>
 				<subtable>
 					<row>
@@ -264,6 +336,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -277,6 +353,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==campaignnamedimension+-+no+other+dimension+for+this+visit</segment>
 			</row>
 			<row>
@@ -289,6 +369,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==campaign_hashed</segment>
 				<subtable>
 					<row>
@@ -301,6 +385,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -328,6 +416,12 @@
 				</goals>
 				<nb_conversions>3</nb_conversions>
 				<revenue>4444</revenue>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 				<segment>referrerType==campaign;referrerName==campaign_with_two_goals_conversions</segment>
 			</row>
 			<row>
@@ -340,6 +434,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==default_offer</segment>
 				<subtable>
 					<row>
@@ -352,6 +450,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -365,6 +467,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...</segment>
 				<subtable>
 					<row>
@@ -377,6 +483,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -390,6 +500,10 @@
 				<sum_visit_length>721</sum_visit_length>
 				<bounce_count>0</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==november_offer</segment>
 				<subtable>
 					<row>
@@ -402,6 +516,10 @@
 						<sum_visit_length>721</sum_visit_length>
 						<bounce_count>0</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -415,6 +533,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 				<segment>referrerType==campaign;referrerName==october_offer</segment>
 				<subtable>
 					<row>
@@ -427,6 +549,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.9%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>6.3%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -462,6 +588,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 				<segment>campaignName==ecommerce_campaign</segment>
 				<subtable>
 					<row>
@@ -494,6 +626,12 @@
 						</goals>
 						<nb_conversions>1</nb_conversions>
 						<revenue>555</revenue>
+						<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+						<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+						<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
+						<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -507,6 +645,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==10th</segment>
 				<subtable>
 					<row>
@@ -519,6 +661,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -532,6 +678,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==11th</segment>
 				<subtable>
 					<row>
@@ -544,6 +694,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -557,6 +711,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==12th</segment>
 				<subtable>
 					<row>
@@ -569,6 +727,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -582,6 +744,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==13th</segment>
 				<subtable>
 					<row>
@@ -594,6 +760,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -607,6 +777,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==14th</segment>
 				<subtable>
 					<row>
@@ -619,6 +793,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -632,6 +810,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==15th</segment>
 				<subtable>
 					<row>
@@ -644,6 +826,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -657,6 +843,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==16th</segment>
 				<subtable>
 					<row>
@@ -669,6 +859,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -682,6 +876,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==17th</segment>
 				<subtable>
 					<row>
@@ -694,6 +892,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -707,6 +909,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==campaignnamedimension+-+no+other+dimension+for+this+visit</segment>
 			</row>
 			<row>
@@ -719,6 +925,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==campaign_hashed</segment>
 				<subtable>
 					<row>
@@ -731,6 +941,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -758,6 +972,12 @@
 				</goals>
 				<nb_conversions>3</nb_conversions>
 				<revenue>4444</revenue>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 				<segment>campaignName==campaign_with_two_goals_conversions</segment>
 			</row>
 			<row>
@@ -770,6 +990,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==default_offer</segment>
 				<subtable>
 					<row>
@@ -782,6 +1006,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -795,6 +1023,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22nam</segment>
 				<subtable>
 					<row>
@@ -807,6 +1039,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -820,6 +1056,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==november_offer</segment>
 				<subtable>
 					<row>
@@ -832,6 +1072,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -845,6 +1089,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==october_offer</segment>
 				<subtable>
 					<row>
@@ -857,6 +1105,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -870,6 +1122,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 				<segment>campaignName==should_be_new_visit</segment>
 			</row>
 		</result>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getPlacement_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getPlacement_day.xml
@@ -33,6 +33,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 				<segment>campaignPlacement==ecommmerce_campaignplacement</segment>
 			</row>
 			<row>
@@ -45,6 +51,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==bottom</segment>
 			</row>
 			<row>
@@ -57,6 +67,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==bottom-left</segment>
 			</row>
 			<row>
@@ -69,6 +83,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==center</segment>
 			</row>
 			<row>
@@ -81,6 +99,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==google+ads</segment>
 			</row>
 			<row>
@@ -93,6 +115,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==google+search</segment>
 			</row>
 			<row>
@@ -105,6 +131,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==left</segment>
 			</row>
 			<row>
@@ -117,6 +147,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==middle</segment>
 			</row>
 			<row>
@@ -129,6 +163,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==right</segment>
 			</row>
 			<row>
@@ -141,6 +179,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==top</segment>
 			</row>
 			<row>
@@ -153,6 +195,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 				<segment>campaignPlacement==top-right</segment>
 			</row>
 		</result>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getSourceMedium_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getSourceMedium_day.xml
@@ -33,6 +33,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 				<subtable>
 					<row>
 						<label>ecommerce_campaign</label>
@@ -64,6 +70,12 @@
 						</goals>
 						<nb_conversions>1</nb_conversions>
 						<revenue>555</revenue>
+						<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+						<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+						<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+						<revenue_percent_of_total>100%</revenue_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -77,6 +89,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;nam</label>
@@ -88,6 +104,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -101,6 +121,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>october_offer</label>
@@ -112,6 +136,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -125,6 +153,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>november_offer</label>
@@ -136,6 +168,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -149,6 +185,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>10th</label>
@@ -160,6 +200,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -173,6 +217,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>11th</label>
@@ -184,6 +232,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -197,6 +249,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>12th</label>
@@ -208,6 +264,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -221,6 +281,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>13th</label>
@@ -232,6 +296,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -245,6 +313,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>14th</label>
@@ -256,6 +328,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -269,6 +345,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>15th</label>
@@ -280,6 +360,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -293,6 +377,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>16th</label>
@@ -304,6 +392,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>
@@ -317,6 +409,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<subtable>
 					<row>
 						<label>17th</label>
@@ -328,6 +424,10 @@
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>1</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
+						<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+						<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+						<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+						<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 					</row>
 				</subtable>
 			</row>

--- a/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getSource_day.xml
+++ b/tests/System/expected/test_multipleDatesSites___MarketingCampaignsReporting.getSource_day.xml
@@ -33,6 +33,12 @@
 				</goals>
 				<nb_conversions>1</nb_conversions>
 				<revenue>555</revenue>
+				<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+				<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+				<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+				<revenue_percent_of_total>100%</revenue_percent_of_total>
 				<segment>campaignSource==ecommerce_source</segment>
 			</row>
 			<row>
@@ -45,6 +51,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==lenghty+%22source%22...lenghty+%22source%22...lenghty+%22source%22...</segment>
 			</row>
 			<row>
@@ -57,6 +67,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_6</segment>
 			</row>
 			<row>
@@ -69,6 +83,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_7</segment>
 			</row>
 			<row>
@@ -81,6 +99,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_10</segment>
 			</row>
 			<row>
@@ -93,6 +115,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_11</segment>
 			</row>
 			<row>
@@ -105,6 +131,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_12</segment>
 			</row>
 			<row>
@@ -117,6 +147,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_13</segment>
 			</row>
 			<row>
@@ -129,6 +163,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_14</segment>
 			</row>
 			<row>
@@ -141,6 +179,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_15</segment>
 			</row>
 			<row>
@@ -153,6 +195,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_16</segment>
 			</row>
 			<row>
@@ -165,6 +211,10 @@
 				<sum_visit_length>0</sum_visit_length>
 				<bounce_count>1</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
+				<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 				<segment>campaignSource==newsletter_17</segment>
 			</row>
 		</result>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getContent_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getContent_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>9</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>75%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>75%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>75%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignContent>none</MarketingCampaignsReporting_CampaignContent>
 		<segment>campaignContent==none</segment>
 	</row>
@@ -43,6 +47,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignContent>ecommerce_content</MarketingCampaignsReporting_CampaignContent>
 		<segment>campaignContent==ecommerce_content</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignContent>contains personalized campaigns for client</MarketingCampaignsReporting_CampaignContent>
 		<segment>campaignContent==contains+personalized+campaigns+for+client</segment>
 	</row>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getGroup_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getGroup_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>ecommmerce_campaigngroup</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==ecommmerce_campaigngroup</segment>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>audience group 1</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==audience+group+1</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg1</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg1</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg2</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg2</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg3</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg3</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg4</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg4</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg5</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg5</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg6</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg6</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg7</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg7</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>cg8</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==cg8</segment>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignGroup>group 1</MarketingCampaignsReporting_CampaignGroup>
 		<segment>campaignGroup==group+1</segment>
 	</row>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getId_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getId_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>campaign_id_kaboom</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==campaign_id_kaboom</segment>
 	</row>
@@ -43,6 +47,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>ecommmerce_campaignid</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==ecommmerce_campaignid</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid1</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid1</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid2</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid2</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid3</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid3</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid4</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid4</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid5</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid5</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid6</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid6</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid7</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid7</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignId>cid8</MarketingCampaignsReporting_CampaignId>
 		<segment>campaignId==cid8</segment>
 	</row>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getKeyword_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getKeyword_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>13.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>13.3%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>ecommerce_keyword</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==ecommerce_keyword</segment>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>13.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>13.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>13.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>mot_clé_pépère</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==mot_cl%C3%A9_p%C3%A9p%C3%A8re</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword a</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+a</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword b</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+b</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword c</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+c</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword d</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+d</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword e</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+e</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword f</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+f</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword from #hash tag parameter</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+from+%23hash+tag+parameter</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword g</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+g</segment>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>keyword h</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==keyword+h</segment>
 	</row>
@@ -173,6 +219,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;k</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22keyword%22...lenghty+%22k</segment>
 	</row>
@@ -186,6 +236,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>6.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>6.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>6.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignKeyword>not_an_advanced_campaign_at_first</MarketingCampaignsReporting_CampaignKeyword>
 		<segment>campaignKeyword==not_an_advanced_campaign_at_first</segment>
 	</row>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getMedium_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getMedium_day.xml
@@ -10,6 +10,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>10</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>83.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>83.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>83.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignMedium>email</MarketingCampaignsReporting_CampaignMedium>
 		<segment>campaignMedium==email</segment>
 	</row>
@@ -43,6 +47,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignMedium>ecommerce_medium</MarketingCampaignsReporting_CampaignMedium>
 		<segment>campaignMedium==ecommerce_medium</segment>
 	</row>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getName_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getName_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>11.1%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>11.1%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>25%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>11.1%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>11.1%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>ecommerce_campaign</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>ecommerce_keyword - ecommerce_content</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==ecommerce_campaign</segment>
@@ -44,6 +50,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>10th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword a - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==10th</segment>
@@ -58,6 +68,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>11th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword b - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==11th</segment>
@@ -72,6 +86,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>12th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword c - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==12th</segment>
@@ -86,6 +104,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>13th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword d - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==13th</segment>
@@ -100,6 +122,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>14th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword e - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==14th</segment>
@@ -114,6 +140,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>15th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword f - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==15th</segment>
@@ -128,6 +158,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>16th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword g - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==16th</segment>
@@ -142,6 +176,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>17th</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword h - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==17th</segment>
@@ -156,6 +194,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>campaignnamedimension - no other dimension for this visit</MarketingCampaignsReporting_CampaignName>
 		<segment>campaignName==campaignnamedimension+-+no+other+dimension+for+this+visit</segment>
 	</row>
@@ -169,6 +211,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>campaign_hashed</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>keyword from #hash tag parameter</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==campaign_hashed</segment>
@@ -197,6 +243,12 @@
 		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>4444</revenue>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>50%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>75%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>88.9%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>campaign_with_two_goals_conversions</MarketingCampaignsReporting_CampaignName>
 		<segment>campaignName==campaign_with_two_goals_conversions</segment>
 	</row>
@@ -210,6 +262,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>default_offer</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>not_an_advanced_campaign_at_first</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==default_offer</segment>
@@ -224,6 +280,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;nam</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;keyword&quot;...lenghty &quot;k</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22name%22...lenghty+%22nam</segment>
@@ -238,6 +298,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>november_offer</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>mot_clé_pépère - contains personalized campaigns for client</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==november_offer</segment>
@@ -252,6 +316,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>october_offer</MarketingCampaignsReporting_CampaignName>
 		<MarketingCampaignsReporting_CombinedKeywordContent>mot_clé_pépère - none</MarketingCampaignsReporting_CombinedKeywordContent>
 		<segment>campaignName==october_offer</segment>
@@ -266,6 +334,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>5.6%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>5.6%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignName>should_be_new_visit</MarketingCampaignsReporting_CampaignName>
 		<segment>campaignName==should_be_new_visit</segment>
 	</row>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getPlacement_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getPlacement_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>16.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>16.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>16.7%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>ecommmerce_campaignplacement</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==ecommmerce_campaignplacement</segment>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>bottom</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==bottom</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>bottom-left</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==bottom-left</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>center</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==center</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>google ads</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==google+ads</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>google search</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==google+search</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>left</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==left</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>middle</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==middle</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>right</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==right</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>top</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==top</segment>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>8.3%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>8.3%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>8.3%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignPlacement>top-right</MarketingCampaignsReporting_CampaignPlacement>
 		<segment>campaignPlacement==top-right</segment>
 	</row>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getSourceMedium_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getSourceMedium_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>ecommerce_source - ecommerce_medium</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>ecommerce_campaign</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>lenghty &quot;source&quot;...lenghty &quot;source&quot;...lenghty &quot;source&quot;...</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;name&quot;...lenghty &quot;nam</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_6 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>october_offer</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_7 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>november_offer</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_10 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>10th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_11 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>11th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_12 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>12th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_13 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>13th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_14 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>14th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_15 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>15th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_16 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>16th</MarketingCampaignsReporting_CampaignName>
 	</row>
@@ -173,6 +219,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSourceMedium>newsletter_17 - email</MarketingCampaignsReporting_CampaignSourceMedium>
 		<MarketingCampaignsReporting_CampaignName>17th</MarketingCampaignsReporting_CampaignName>
 	</row>

--- a/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getSource_day.xml
+++ b/tests/System/expected/test_segmentedMatchAll__MarketingCampaignsReporting.getSource_day.xml
@@ -30,6 +30,12 @@
 		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>555</revenue>
+		<nb_visits_percent_of_total>15.4%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>15.4%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>100%</nb_visits_converted_percent_of_total>
+		<nb_conversions_percent_of_total>100%</nb_conversions_percent_of_total>
+		<bounce_count_percent_of_total>15.4%</bounce_count_percent_of_total>
+		<revenue_percent_of_total>100%</revenue_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>ecommerce_source</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==ecommerce_source</segment>
 	</row>
@@ -43,6 +49,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>lenghty &quot;source&quot;...lenghty &quot;source&quot;...lenghty &quot;source&quot;...</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==lenghty+%22source%22...lenghty+%22source%22...lenghty+%22source%22...</segment>
 	</row>
@@ -56,6 +66,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_6</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_6</segment>
 	</row>
@@ -69,6 +83,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_7</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_7</segment>
 	</row>
@@ -82,6 +100,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_10</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_10</segment>
 	</row>
@@ -95,6 +117,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_11</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_11</segment>
 	</row>
@@ -108,6 +134,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_12</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_12</segment>
 	</row>
@@ -121,6 +151,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_13</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_13</segment>
 	</row>
@@ -134,6 +168,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_14</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_14</segment>
 	</row>
@@ -147,6 +185,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_15</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_15</segment>
 	</row>
@@ -160,6 +202,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_16</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_16</segment>
 	</row>
@@ -173,6 +219,10 @@
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<nb_visits_percent_of_total>7.7%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>7.7%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>7.7%</bounce_count_percent_of_total>
 		<MarketingCampaignsReporting_CampaignSource>newsletter_17</MarketingCampaignsReporting_CampaignSource>
 		<segment>campaignSource==newsletter_17</segment>
 	</row>


### PR DESCRIPTION
Companion to matomo-org/matomo#24983 (Matomo 6, DEV-14950), which adds always-on `{metric}_percent_of_total` columns to report rows in API responses.

These expected files only pass against a Matomo 6 core containing that change, so this PR stays draft until the core PR is merged. CI here may be red against older core branches.

Note the branch is based on the commit currently pinned by the matomo 6.x-dev submodule, not the tip of 5.x-dev, so the gitlink in the core PR advances cleanly.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules