### PR TITLE
Count tracked visits from the log tables in the CNIL masking test

### DIFF
--- a/tests/Integration/ForceNewVisitTest.php
+++ b/tests/Integration/ForceNewVisitTest.php
@@ -9,7 +9,9 @@
 
 namespace Piwik\Plugins\MarketingCampaignsReporting\tests\Integration;
 
+use Piwik\Common;
 use Piwik\Date;
+use Piwik\Db;
 use Piwik\Plugins\Live\API as LiveAPI;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignContent;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignGroup;
@@ -163,7 +165,7 @@ class ForceNewVisitTest extends IntegrationTestCase
 
             Fixture::checkResponse($this->tracker->doTrackPageView('Track visit with masked campaign parameters'));
 
-            $this->assertVisits(1, 1, 1);
+            $this->assertTrackedCounts(1, 1, 1);
 
             $this->moveTimeForward(0.05);
 
@@ -182,7 +184,7 @@ class ForceNewVisitTest extends IntegrationTestCase
 
             Fixture::checkResponse($this->tracker->doTrackPageView('Track another time with same masked campaign parameters'));
 
-            $this->assertVisits(1, 1, 2);
+            $this->assertTrackedCounts(1, 1, 2);
         } finally {
             PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false, $this->idSite);
         }
@@ -314,6 +316,25 @@ class ForceNewVisitTest extends IntegrationTestCase
         $this->assertEquals($visitsExpected, $counters[0]['visits']);
         $this->assertEquals($uniqueVisitsExpected, $counters[0]['visitors']);
         $this->assertEquals($actionsExpected, $counters[0]['actions']);
+    }
+
+    /**
+     * Live.getCounters rounds its output while a data-rounding policy such as CNIL is active, which would
+     * collapse the small exact counts this test relies on (e.g. 1 and 2 would both become 10). Read the
+     * tracked counts straight from the log tables instead so the assertions stay rounding-immune.
+     */
+    private function assertTrackedCounts($visitsExpected, $uniqueVisitsExpected, $actionsExpected)
+    {
+        $visits   = Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('log_visit')
+            . ' WHERE idsite = ?', [$this->idSite]);
+        $visitors = Db::fetchOne('SELECT COUNT(DISTINCT idvisitor) FROM ' . Common::prefixTable('log_visit')
+            . ' WHERE idsite = ?', [$this->idSite]);
+        $actions  = Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('log_link_visit_action')
+            . ' WHERE idsite = ?', [$this->idSite]);
+
+        $this->assertEquals($visitsExpected, $visits);
+        $this->assertEquals($uniqueVisitsExpected, $visitors);
+        $this->assertEquals($actionsExpected, $actions);
     }
 
     private function getUrlForTracking($params, $path = '')


### PR DESCRIPTION
### Description

`Live.getCounters` now applies privacy-safe rounding while a data-rounding policy such as CNIL is active. `ForceNewVisitTest`'s masked-campaign case enables CNIL and asserts small exact counts (1 vs 2) read through `Live.getCounters`, which would collapse to 10 under rounding.

This reads the tracked counts directly from the log tables so those assertions stay rounding-immune.

Supports the 5.x backport of matomo-org/matomo#24929.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Backport of #228.
