### PR TITLE
Sync the pre-push hook and turn on verify-hook [ignore_release]

### DIFF
--- a/.git-hooks-matomo/pre-push
+++ b/.git-hooks-matomo/pre-push
@@ -67,38 +67,96 @@ fi
 # Basic setup
 cd "$REPO_DIR" || exit 1
 STATUS=0
-# The branch to diff against is the remote's default, not a fixed name: plugins on
-# 6.x-dev would otherwise be compared against 5.x-dev and diff the wrong files.
-# origin/HEAD is only set if the clone recorded it, so fall back to asking the remote,
-# then to 5.x-dev for a clone that can reach neither.
-MAIN_BRANCH=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
-if [[ -z "$MAIN_BRANCH" ]]; then
-  MAIN_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
-fi
-MAIN_BRANCH=${MAIN_BRANCH:-5.x-dev}
-
-# PHPStan analyses the plugin against whichever Matomo checkout happens to contain it, which is not
-# necessarily the major this branch targets. A 6.x-dev branch sitting in a Matomo 5 checkout is
-# analysed against Matomo 5, and the findings look entirely real -- correct files, correct line
-# numbers -- for signatures that simply differ between the majors. Warn rather than fail: the
-# mismatch is sometimes deliberate, and a hard failure on a guess is what teaches --no-verify.
-CORE_VERSION_FILE="$MATOMO_DIR/core/Version.php"
-if [ -f "$CORE_VERSION_FILE" ]; then
-  CORE_MAJOR=$(sed -n "s/.*const VERSION = '\([0-9]\{1,\}\)\..*/\1/p" "$CORE_VERSION_FILE" | head -1)
-  # Only `<major>.x-dev` says anything about the target major; any other branch name is left alone.
-  BRANCH_MAJOR=$(printf '%s' "$MAIN_BRANCH" | sed -n 's/^\([0-9]\{1,\}\)\.x-dev$/\1/p')
-  if [ -n "$CORE_MAJOR" ] && [ -n "$BRANCH_MAJOR" ] && [ "$CORE_MAJOR" != "$BRANCH_MAJOR" ]; then
-    echo
-    echo "WARNING: analysing against Matomo ${CORE_MAJOR}.x in $MATOMO_DIR, but this plugin's"
-    echo "         default branch is $MAIN_BRANCH. Findings below may not match CI, which"
-    echo "         analyses against Matomo ${BRANCH_MAJOR}.x. Check a finding against a Matomo"
-    echo "         ${BRANCH_MAJOR}.x checkout before acting on it."
-    echo
-  fi
-fi
 ZERO_OID='0000000000000000000000000000000000000000'
 PHPSTAN_CREATED_CONFIG=phpstan/phpstan.created.neon
 PHPSTAN_MODIFIED_CONFIG=phpstan/phpstan.modified.neon
+
+
+
+### Work out what a pushed commit should be compared against. ###
+
+# The nearest origin/<major>.x-dev, measured in commits between the merge base and the push.
+# origin/HEAD is wrong twice over: git records it at clone time and never refreshes it, so a clone
+# made while the default was 5.x-dev still names 5.x-dev long after the plugin moved to 6.x-dev;
+# and the default branch is not the base of a backport branch in any case. Both mistakes widen the
+# diff to files the push never touched. Distance needs no network and no naming convention.
+#
+# Assigns MAIN_BRANCH and BASE_BRANCH_TIED instead of echoing: reading stdout needs a command
+# substitution, and the subshell would throw the tie flag away. Tied means two majors are equally
+# near -- the branch predates their divergence, so the merge base, and with it the file list, is
+# the same either way and only the label is a guess.
+#
+# $1 -- the pushed commit
+resolve_base_branch() {
+  local commit="$1"
+  local ref merge_base distance best_branch='' best_distance=''
+
+  BASE_BRANCH_TIED=0
+  for ref in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/*.x-dev'); do
+    merge_base=$(git merge-base "$commit" "$ref" 2>/dev/null) || continue
+    distance=$(git rev-list --count "${merge_base}..${commit}")
+    if [[ -z "$best_distance" || "$distance" -lt "$best_distance" ]]; then
+      best_distance=$distance
+      best_branch=${ref#origin/}
+      # A strictly closer candidate settles it, including over an earlier tie between two
+      # branches that both just lost.
+      BASE_BRANCH_TIED=0
+    elif [[ "$distance" -eq "$best_distance" ]]; then
+      # for-each-ref sorts ascending, so taking the later ref means the highest major wins a tie.
+      best_branch=${ref#origin/}
+      BASE_BRANCH_TIED=1
+    fi
+  done
+
+  if [[ -n "$best_branch" ]]; then
+    MAIN_BRANCH=$best_branch
+    return 0
+  fi
+
+  # No <major>.x-dev refs at all -- a single-branch clone, or a fork. Fall back to the remote's
+  # default branch, then to a fixed name for a clone that can reach neither. Neither says anything
+  # about the target major, so treat it as tied.
+  local fallback
+  fallback=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+  if [[ -z "$fallback" ]]; then
+    fallback=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+  fi
+  BASE_BRANCH_TIED=1
+  MAIN_BRANCH=${fallback:-5.x-dev}
+}
+
+# PHPStan analyses the plugin against whichever Matomo checkout happens to contain it, which is not
+# necessarily the major the push is based on. A 6.x-dev branch sitting in a Matomo 5 checkout is
+# analysed against Matomo 5, and the findings look entirely real -- correct files, correct line
+# numbers -- for signatures that simply differ between the majors. Warn rather than fail: the
+# mismatch is sometimes deliberate, and a hard failure on a guess is what teaches --no-verify.
+#
+# $1 -- the base branch resolved for the push
+WARNED_BASE_BRANCHES=''
+warn_on_core_major_mismatch() {
+  local base_branch="$1"
+  local core_version_file="$MATOMO_DIR/core/Version.php"
+  local core_major branch_major
+
+  [ -f "$core_version_file" ] || return 0
+  # A tied resolution did not establish a target major, so there is nothing to compare against.
+  [ "${BASE_BRANCH_TIED:-0}" -eq 0 ] || return 0
+  # Once per base branch, not once per pushed ref.
+  case " $WARNED_BASE_BRANCHES " in *" $base_branch "*) return 0 ;; esac
+  WARNED_BASE_BRANCHES="$WARNED_BASE_BRANCHES $base_branch"
+
+  core_major=$(sed -n "s/.*const VERSION = '\([0-9]\{1,\}\)\..*/\1/p" "$core_version_file" | head -1)
+  # Only `<major>.x-dev` says anything about the target major; any other branch name is left alone.
+  branch_major=$(printf '%s' "$base_branch" | sed -n 's/^\([0-9]\{1,\}\)\.x-dev$/\1/p')
+  [ -n "$core_major" ] && [ -n "$branch_major" ] && [ "$core_major" != "$branch_major" ] || return 0
+
+  echo
+  echo "WARNING: analysing against Matomo ${core_major}.x in $MATOMO_DIR, but this push is based"
+  echo "         on $base_branch. Findings below may not match CI, which analyses against Matomo"
+  echo "         ${branch_major}.x. Check a finding against a Matomo ${branch_major}.x checkout"
+  echo "         before acting on it."
+  echo
+}
 
 
 
@@ -116,7 +174,7 @@ check_pushed_commit() {
     return 0
   fi
 
-  # Use the merge base with the remote main branch: the local branch can be stale
+  # Use the merge base with the remote base branch: the local branch can be stale
   # or missing, which silently widens the diff to files the push doesn't touch.
   local diff_base
   diff_base=$(git merge-base "$commit" "origin/${MAIN_BRANCH}" 2>/dev/null)
@@ -151,7 +209,10 @@ while read -r local_ref local_oid remote_ref remote_oid; do
   if [[ "$local_oid" == "$ZERO_OID" ]]; then
     continue # deleting the remote ref, nothing is pushed
   fi
-  echo "Checking ${local_ref} (${local_oid})"
+  # Resolved per ref: one push can carry branches based on different majors.
+  resolve_base_branch "$local_oid"
+  warn_on_core_major_mismatch "$MAIN_BRANCH"
+  echo "Checking ${local_ref} (${local_oid}) against origin/${MAIN_BRANCH}"
   check_pushed_commit "$local_oid" A "$PHPSTAN_CREATED_CONFIG" "created" < /dev/null || STATUS=1
   # CMR, not CM: a renamed-and-modified PHP file has status R and would otherwise skip the check.
   check_pushed_commit "$local_oid" CMR "$PHPSTAN_MODIFIED_CONFIG" "modified" < /dev/null || STATUS=1
@@ -167,5 +228,51 @@ done
 #     echo "Running PHPstan at a base level on all plugin files"
 #   $COMMAND analyse -c ${PLUGIN_PATH}/${PHPSTAN_BASE_CONFIG} || STATUS=1
 # fi
+
+# A plugin whose core.hooksPath is unset has this file and no way to reach it, and nothing runs to
+# say so -- which is exactly why four plugins went a year without the check ever firing. A hook that
+# does run can see its siblings, so the working ones report the silent ones.
+#
+# Only plugins that ship the file are considered: a plugin without one has no hook to activate, and
+# pointing core.hooksPath at a directory that does not exist would be worse than leaving it alone --
+# git then runs no hook at all, including anything the repository keeps in .git/hooks, and says
+# nothing about it.
+#
+# Advisory, and at most once a day. Someone else's configuration is not grounds to fail a push.
+audit_sibling_plugins() {
+  local plugins_dir="${MATOMO_DIR}/plugins"
+  local marker="${MATOMO_DIR}/tmp/.matomo-hook-audit"
+  local dir inactive=()
+
+  [ -d "$plugins_dir" ] || return 0
+
+  # `find -mmin` rather than `stat`, whose format flags differ between GNU and BSD.
+  if [ -f "$marker" ] && [ -z "$(find "$marker" -mmin +1440 2>/dev/null)" ]; then
+    return 0
+  fi
+  if mkdir -p "${MATOMO_DIR}/tmp" 2>/dev/null; then
+    : > "$marker" 2>/dev/null || true
+  fi
+
+  for dir in "$plugins_dir"/*/; do
+    [ -f "${dir}.git-hooks-matomo/pre-push" ] || continue
+    git -C "$dir" rev-parse --git-dir >/dev/null 2>&1 || continue
+    [ -n "$(git -C "$dir" config --get core.hooksPath 2>/dev/null)" ] && continue
+    inactive+=("$(basename "$dir")")
+  done
+
+  [ ${#inactive[@]} -eq 0 ] && return 0
+
+  echo
+  echo "NOTE: ${#inactive[@]} plugin(s) ship a pre-push hook that never runs, because"
+  echo "      core.hooksPath is not set in them: ${inactive[*]}"
+  echo "      Activate with add-git-hooks-to-plugins.sh from matomo-developer-tools."
+  echo
+}
+
+# Only on a push that is going through: a rejected push's output should stay about the rejection.
+if [[ $STATUS -eq 0 ]]; then
+  audit_sibling_plugins
+fi
 
 exit $STATUS

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -10,3 +10,4 @@ jobs:
     uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-phpstan.yml@main
     with:
       plugin-name: MarketingCampaignsReporting
+      verify-hook: true


### PR DESCRIPTION
## Description

The bundled `.git-hooks-matomo/pre-push` picks the branch it diffs a push against from `origin/HEAD`. Git records that ref when a repository is cloned and never refreshes it, so a clone made while the default branch was `5.x-dev` keeps naming `5.x-dev` long after the plugin moved to `6.x-dev`. The merge base then lands far too far back, and files the push never touched join the analysis — which can reject a push over findings in code the branch does not contain.

This takes the canonical copy from [`plugin-ci-workflows`](https://github.com/matomo-org/plugin-ci-workflows), which resolves the base per pushed ref: the nearest `origin/<major>.x-dev`, measured in commits from the merge base. That needs no network call and no branch-naming convention, and it gets backports right — a branch cut from `5.x-dev` still resolves to `5.x-dev`.

It also brings two things this copy did not have: a warning when the Matomo checkout's major differs from the branch's, and a note listing sibling plugins that ship a hook no `core.hooksPath` points at, so a hook that never runs stops being invisible.

`verify-hook: true` is set on the PHPStan caller in the same change, so the copy and canonical cannot drift apart again without failing the build.

No functional change to the plugin — this is developer tooling and CI configuration only.

## Issue No

PG-4897. Canonical fix: matomo-org/plugin-ci-workflows#7

## Steps to Replicate the Issue

1. In a clone made before the plugin's default branch became `6.x-dev`, run `git symbolic-ref --short refs/remotes/origin/HEAD` — it still reports `origin/5.x-dev`.
2. Expected: pushing a `6.x-dev` branch analyses only the files that branch changes.
3. Actual: the hook diffs against `origin/5.x-dev`, analyses everything gained since the two lines diverged, and can reject the push over untouched files.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
