### PR TITLE
Count tracked visits from the log tables in the CNIL masking test [ignore_release]

### DIFF
--- a/tests/Integration/ForceNewVisitTest.php
+++ b/tests/Integration/ForceNewVisitTest.php
@@ -9,7 +9,9 @@
 
 namespace Piwik\Plugins\MarketingCampaignsReporting\tests\Integration;
 
+use Piwik\Common;
 use Piwik\Date;
+use Piwik\Db;
 use Piwik\Plugins\Live\API as LiveAPI;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignContent;
 use Piwik\Plugins\MarketingCampaignsReporting\Columns\CampaignGroup;
@@ -163,7 +165,7 @@ class ForceNewVisitTest extends IntegrationTestCase
 
             Fixture::checkResponse($this->tracker->doTrackPageView('Track visit with masked campaign parameters'));
 
-            $this->assertVisits(1, 1, 1);
+            $this->assertTrackedCounts(1, 1, 1);
 
             $this->moveTimeForward(0.05);
 
@@ -182,7 +184,7 @@ class ForceNewVisitTest extends IntegrationTestCase
 
             Fixture::checkResponse($this->tracker->doTrackPageView('Track another time with same masked campaign parameters'));
 
-            $this->assertVisits(1, 1, 2);
+            $this->assertTrackedCounts(1, 1, 2);
         } finally {
             PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false, $this->idSite);
         }
@@ -314,6 +316,25 @@ class ForceNewVisitTest extends IntegrationTestCase
         $this->assertEquals($visitsExpected, $counters[0]['visits']);
         $this->assertEquals($uniqueVisitsExpected, $counters[0]['visitors']);
         $this->assertEquals($actionsExpected, $counters[0]['actions']);
+    }
+
+    /**
+     * Live.getCounters rounds its output while a data-rounding policy such as CNIL is active, which would
+     * collapse the small exact counts this test relies on (e.g. 1 and 2 would both become 10). Read the
+     * tracked counts straight from the log tables instead so the assertions stay rounding-immune.
+     */
+    private function assertTrackedCounts($visitsExpected, $uniqueVisitsExpected, $actionsExpected)
+    {
+        $visits   = Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('log_visit')
+            . ' WHERE idsite = ?', [$this->idSite]);
+        $visitors = Db::fetchOne('SELECT COUNT(DISTINCT idvisitor) FROM ' . Common::prefixTable('log_visit')
+            . ' WHERE idsite = ?', [$this->idSite]);
+        $actions  = Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('log_link_visit_action')
+            . ' WHERE idsite = ?', [$this->idSite]);
+
+        $this->assertEquals($visitsExpected, $visits);
+        $this->assertEquals($uniqueVisitsExpected, $visitors);
+        $this->assertEquals($actionsExpected, $actions);
     }
 
     private function getUrlForTracking($params, $path = '')


### PR DESCRIPTION
## Description

The 5.x-dev build has been failing since 22 August because `ForceNewVisitTest::testTrackingWithSameParametersDoesNotForceNewVisitWhenCampaignValuesAreMasked` asserts exact visit counts read back through `Live.getCounters` while the CNIL policy is active. Core #25108 brought the privacy-safe rounding of real-time counters to the 5.x line, so those counters are now rounded to the nearest ten with a minimum of ten, and a single tracked visit reads as 10. Campaign tracking itself is unaffected — only the test's way of counting was.

This is a backport of #228, already on 6.x-dev: the masked-campaign assertions count `log_visit` and `log_link_visit_action` rows directly, which stays correct whether or not a rounding policy is active. Test-only, so no version bump or changelog entry.

## Issue No

Related to matomo-org/matomo#25108. Backport of #228.

## Steps to Replicate the Issue

1. Run the plugin's PluginTests suite on 5.x-dev against the maximum supported Matomo 5 version (the test skips itself on older core, which is why only that half of the matrix is red).
2. Expected: `ForceNewVisitTest` passes, the masked-campaign requests being counted as one visit.
3. Actual: `Failed asserting that 10 matches expected 1`.

## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
