### PR TITLE
Move the checks onto the shared umbrella and build the other dev branch weekly [ignore_release]

### DIFF
--- a/.github/workflows/weekly-branch-sweep.yml
+++ b/.github/workflows/weekly-branch-sweep.yml
@@ -1,0 +1,25 @@
+# Dispatches this plugin's build for each maintained branch that is not the default one, because
+# GitHub only ever runs `schedule` from the default branch's copy of a workflow file. The logic
+# lives in matomo-org/plugin-ci-workflows; see the "Branch sweep" section of its README.md for
+# why this dispatches rather than building another branch's source here.
+
+name: Weekly branch sweep
+
+on:
+  schedule:
+    # Sunday, so it does not compete with this plugin's own Saturday build. Keeps the minute and
+    # hour of matomo-tests.yml's cron, so the fleet stays staggered across the window.
+    - cron: '55 2 * * 0'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sweep:
+    # Granted by the caller because permissions can only be maintained or reduced down a call
+    # chain, never elevated: the called workflow declares these too, but that can only cap them,
+    # not supply them, so without this block the dispatch is unauthorised.
+    permissions:
+      actions: write
+      contents: read
+    uses: matomo-org/plugin-ci-workflows/.github/workflows/plugin-branch-sweep.yml@main


### PR DESCRIPTION
## Description

Separate commits so any part can be reverted on its own.

**The pull request checks move behind the shared umbrella.** The workflows this replaces were already thin callers of the same shared workflows, so what changes is that one caller invokes them rather than several — a check added centrally now reaches this plugin without a pull request here. It also drops the `concurrency` group the AI checklist workflow carried, which spans both of the umbrella's lanes and silently defeats them.

Opted out where the check does not apply here: `skip-ALREADY MIGRATED`. Each carries its reason inline.

**The non-default dev branch gets a weekly build.** GitHub only runs a `schedule` trigger from the default branch's copy of a workflow file, so when the default moved the other line stopped being built and nothing said so. The sweep dispatches this plugin's own `matomo-tests.yml` there using this repository's own token — `workflow_dispatch` is a documented exception to the rule that GITHUB_TOKEN-triggered events create no workflow run, so no PAT is involved. The cron is `55 2 * * 0`: this plugin's own minute and hour, moved to Sunday, so it does not compete with the Saturday build and the fleet keeps its stagger.

Verified live on matomo-org/plugin-LogViewer and innocraft/plugin-UsersFlow: a manual dispatch resolved the default branch, dispatched the build on the other one, and that build completed green attributed to that branch — which is what the plugin build dashboard's per-branch badges read.

## Issue No

No GitHub issue.

## Steps to Replicate the Issue

1. Note that the `matomo-tests.yml` cron only ever fires on the default branch.
2. Expected result: the other maintained dev branch is built weekly too.
3. Actual result: it has had no scheduled build since the default branch changed.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
